### PR TITLE
Remove rationale array in favor of session log-based decision tracking

### DIFF
--- a/claudesprint/cli.py
+++ b/claudesprint/cli.py
@@ -944,7 +944,6 @@ def config_show() -> None:
 
     console.print("[bold]\\[debug][/bold]")
     console.print(f"  conversations = {str(config.debug.conversations).lower()}")
-    console.print(f"  max_rationale = {config.debug.max_rationale}")
 
 
 @config_app.command("edit")

--- a/claudesprint/core/sprint_engine.py
+++ b/claudesprint/core/sprint_engine.py
@@ -386,15 +386,12 @@ class SprintEngine:
             )
 
         # Check current_issue.json first (Claude may have written it)
+        # Note: Selection rationale is logged to current_issue.log, not stored in JSON
         updated_issue = self.issue_service.read_current_issue()
         if updated_issue and updated_issue.issue_id:
             issue = sprint.get_issue(updated_issue.issue_id)
             if issue:
-                rationale = (
-                    updated_issue.rationale[0]
-                    if updated_issue.rationale
-                    else "Agent selected"
-                )
+                rationale = "Agent selected"
                 self.issue_service.log_issue_selection(
                     issue.id, issue.title, rationale
                 )

--- a/claudesprint/models/config.py
+++ b/claudesprint/models/config.py
@@ -70,11 +70,6 @@ class ClaudesprintConfig(BaseSettings):
         description="Maximum wait time in seconds for rate limit backoff (default 15 min)",
         validation_alias=AliasChoices("rate_limit_max_wait", "CLAUDESPRINT_RATE_LIMIT_MAX_WAIT"),
     )
-    max_rationale_entries: Annotated[int, Field(ge=5)] = Field(
-        default=20,
-        description="Maximum rationale entries to keep (oldest pruned first)",
-        validation_alias=AliasChoices("max_rationale_entries", "CLAUDESPRINT_MAX_RATIONALE"),
-    )
     heartbeat_timeout: Annotated[int, Field(ge=60)] = Field(
         default=600,
         description="Seconds of inactivity before triggering hung process notification",
@@ -138,7 +133,6 @@ class ClaudesprintConfig(BaseSettings):
             "heartbeat_enabled": "CLAUDESPRINT_HEARTBEAT_ENABLED",
             "heartbeat_timeout": "CLAUDESPRINT_HEARTBEAT_TIMEOUT",
             "debug_conversations": "CLAUDESPRINT_DEBUG_CONVERSATIONS",
-            "max_rationale_entries": "CLAUDESPRINT_MAX_RATIONALE",
         }
 
         # Only include values where env var is not set
@@ -212,7 +206,6 @@ class ClaudesprintConfig(BaseSettings):
             "heartbeat_enabled": "heartbeat_enabled",
             "heartbeat_timeout": "heartbeat_timeout",
             "debug_conversations": "debug_conversations",
-            "max_rationale_entries": "max_rationale_entries",
         }
 
         for field_name, global_key in field_mapping.items():

--- a/claudesprint/models/current_issue.py
+++ b/claudesprint/models/current_issue.py
@@ -219,10 +219,6 @@ class CurrentIssue(BaseModel):
     )
 
     # Context preservation
-    rationale: list[str] = Field(
-        default_factory=list,
-        description="Key decisions made and their reasoning",
-    )
     context: dict[str, str] = Field(
         default_factory=dict,
         description="Arbitrary context data for the session",
@@ -269,38 +265,17 @@ class CurrentIssue(BaseModel):
         """Update the timestamp to current UTC time."""
         self.timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    def prune_rationale(self, max_entries: int = 5) -> int:
-        """Prune rationale array to prevent context window exhaustion.
-
-        Keeps the most recent entries (last N entries).
-        Default is conservative (5) to prevent token bloat in debugging loops.
-
-        Args:
-            max_entries: Maximum number of entries to keep.
-
-        Returns:
-            Number of entries pruned.
-        """
-        if len(self.rationale) <= max_entries:
-            return 0
-
-        pruned_count = len(self.rationale) - max_entries
-        self.rationale = self.rationale[-max_entries:]
-        return pruned_count
-
     def prune_arrays(
         self,
-        max_rationale: int = 5,
         max_changes: int = 20,
         max_commands: int = 30,
     ) -> dict[str, int]:
-        """Prune all arrays that can grow unbounded.
+        """Prune arrays that can grow unbounded.
 
         Conservative defaults prevent context window exhaustion during
         debugging loops (e.g., fix-tests cycling 5+ times).
 
         Args:
-            max_rationale: Maximum rationale entries to keep (default 5).
             max_changes: Maximum file change entries to keep (default 20).
             max_commands: Maximum commands_run entries to keep (default 30).
 
@@ -308,11 +283,6 @@ class CurrentIssue(BaseModel):
             Dict with counts of pruned entries per field.
         """
         pruned = {}
-
-        # Prune rationale - most likely to grow large during debugging
-        if len(self.rationale) > max_rationale:
-            pruned["rationale"] = len(self.rationale) - max_rationale
-            self.rationale = self.rationale[-max_rationale:]
 
         # Prune changes (keep most recent)
         if len(self.changes) > max_changes:
@@ -345,7 +315,6 @@ class CurrentIssue(BaseModel):
             commands_run=[],
             current_failures="",
             retry_count=0,
-            rationale=[],
             context={},
             last_test_run_hash="",
             cached_docs={},
@@ -369,7 +338,7 @@ class CurrentIssue(BaseModel):
             "next_action": self.next_action,
             "assumptions": [],
             "open_questions": [],
-            "rationale": self.rationale,
+            "rationale": [],  # Deprecated - kept for backward compat
             "retry_count": self.retry_count,
             "last_test_run_hash": self.last_test_run_hash,
             "cached_docs": self.cached_docs,

--- a/claudesprint/prompts/PROMPT_browser-validation.md
+++ b/claudesprint/prompts/PROMPT_browser-validation.md
@@ -5,7 +5,7 @@
 
 The `agent-browser` tool is not installed globally. Skip this step:
 - Set `step` to `code-review`
-- Add to `rationale`: "Skipped browser validation: agent-browser not available"
+- Log: "Skipped browser validation: agent-browser not available"
 
 STATUS: SKIP
 {% else %}
@@ -18,7 +18,7 @@ You are a **browser validation agent**. Validate UI features using agent-browser
 
 If NO UI components, skip to code-review:
 - Set `step` to `code-review`
-- Add to `rationale`: "Skipped browser validation: no UI keywords in acceptance criteria"
+- Log: "Skipped browser validation: no UI keywords in acceptance criteria"
 - Exit
 
 ## Get Bearings
@@ -79,7 +79,7 @@ For each UI acceptance criterion verify:
 
 ### If SKIP:
 - Set `step` to `code-review`
-- Add to `rationale`: "Skipped: no UI in acceptance criteria"
+- Log: "Skipped browser validation: no UI in acceptance criteria"
 
 ## Log & Exit
 

--- a/claudesprint/prompts/PROMPT_code-review.md
+++ b/claudesprint/prompts/PROMPT_code-review.md
@@ -46,7 +46,6 @@ For each criterion: Is it implemented? Is it tested? Does it work?
 
 ### If CLEAN:
 - Set `step` to `update-docs`
-- Add to `rationale`: "Code review passed: all AC verified"
 
 ### If blocking issues:
 - Set `step` to `fix-code-review-issues`
@@ -57,6 +56,7 @@ For each criterion: Is it implemented? Is it tested? Does it work?
 ```bash
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] STEP: code-review -> <next>" >> .claudesprint/project/current_issue.log
 echo "  Result: <PASS/ISSUES>" >> .claudesprint/project/current_issue.log
+echo "  Decision: <Code review passed: all AC verified OR blocking issues found>" >> .claudesprint/project/current_issue.log
 ```
 
 ## Rules

--- a/claudesprint/prompts/PROMPT_commit-changes.md
+++ b/claudesprint/prompts/PROMPT_commit-changes.md
@@ -11,7 +11,7 @@ git diff --staged --stat 2>/dev/null || echo "Nothing staged"
 
 If NOT a git repo or nothing staged:
 - Set `step` to `select-issue` (issue complete, select next)
-- Add to `rationale`: "Skipped commit: <reason>"
+- Log: "Skipped commit: <reason>"
 - Exit
 
 ## Get Bearings

--- a/claudesprint/prompts/PROMPT_fix-code-review-issues.md
+++ b/claudesprint/prompts/PROMPT_fix-code-review-issues.md
@@ -26,7 +26,6 @@ Extract: `current_failures` (issues to fix), `next_action` (first issue to addre
 - Set `step` to `run-tests`
 - Clear `current_failures`
 - Add to `changes`: `{"path": "<file>", "summary": "<what fixed>"}`
-- Add to `rationale`: "Fixed review issues: <summary>"
 
 **IMPORTANT**: Preserve existing `changes` array and ADD fix changes.
 
@@ -35,6 +34,7 @@ Extract: `current_failures` (issues to fix), `next_action` (first issue to addre
 ```bash
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] STEP: fix-code-review-issues -> run-tests" >> .claudesprint/project/current_issue.log
 echo "  Fixed: <issues fixed>" >> .claudesprint/project/current_issue.log
+echo "  Decision: Fixed review issues: <summary>" >> .claudesprint/project/current_issue.log
 ```
 
 ## Rules

--- a/claudesprint/prompts/PROMPT_fix-tests.md
+++ b/claudesprint/prompts/PROMPT_fix-tests.md
@@ -41,18 +41,17 @@ Before ANY changes:
 - Set `step` to `run-tests`
 - Clear `current_failures`
 - Add to `changes`: modified test files
-- Add to `rationale`: "Fixed test: <what was wrong>"
 
 ### If code is wrong:
 - Set `step` to `implement`
 - Keep `current_failures`
-- Add to `rationale`: "Re-routing: test correctly expects X, implementation does Y"
 
 ## Log & Exit
 
 ```bash
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] STEP: fix-tests -> <next>" >> .claudesprint/project/current_issue.log
 echo "  Analysis: <test wrong OR code wrong>" >> .claudesprint/project/current_issue.log
+echo "  Decision: <Fixed test: what was wrong OR Re-routing: test expects X, impl does Y>" >> .claudesprint/project/current_issue.log
 ```
 
 ## Rules

--- a/claudesprint/prompts/PROMPT_implement.md
+++ b/claudesprint/prompts/PROMPT_implement.md
@@ -12,7 +12,7 @@ claudesprint-tools sprint details "$ISSUE_ID"
 git log --oneline -5 2>/dev/null || echo "Not a git repo"
 ```
 
-Extract: `issue_id`, `issue_title`, `context.acceptance_criteria`, `current_failures`, `rationale`
+Extract: `issue_id`, `issue_title`, `context.acceptance_criteria`, `current_failures`
 
 If `issue_id` is empty, report the issue.
 
@@ -28,14 +28,13 @@ If `issue_id` is empty, report the issue.
 If routed here from `run-tests`, `fix-tests`, or `browser-validation`:
 - Read `current_failures` for specific issue to fix
 - Focus on fixing that issue first
-- Add rationale for fix approach
+- Log fix approach to `current_issue.log`
 
 ## Update current_issue.json
 
 - Set `step` to `write-tests`
 - Set `goal` to describe test writing
 - Add to `changes`: `{"path": "<file>", "summary": "<what changed>"}`
-- Add to `rationale`: key implementation decisions
 - Clear `current_failures` if fixed
 
 ## Log & Exit
@@ -43,6 +42,7 @@ If routed here from `run-tests`, `fix-tests`, or `browser-validation`:
 ```bash
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] STEP: implement -> write-tests" >> .claudesprint/project/current_issue.log
 echo "  Changes: <files modified>" >> .claudesprint/project/current_issue.log
+echo "  Decision: <key implementation decisions>" >> .claudesprint/project/current_issue.log
 ```
 
 ## Rules

--- a/claudesprint/prompts/PROMPT_read-docs.md
+++ b/claudesprint/prompts/PROMPT_read-docs.md
@@ -34,7 +34,6 @@ Query external docs when using: library APIs, framework patterns, external servi
 
 - Set `step` to `implement`
 - Set `goal` to describe implementation
-- Add to `rationale`: architectural decisions, patterns to follow, library APIs from docs
 - Add `context.external_docs_findings`: key API methods, config patterns, version notes
 
 ## Log & Exit
@@ -42,6 +41,7 @@ Query external docs when using: library APIs, framework patterns, external servi
 ```bash
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] STEP: read-docs -> implement" >> .claudesprint/project/current_issue.log
 echo "  Findings: <key findings>" >> .claudesprint/project/current_issue.log
+echo "  Decision: <architectural decisions, patterns to follow, library APIs>" >> .claudesprint/project/current_issue.log
 ```
 
 ## Rules

--- a/claudesprint/prompts/PROMPT_run-tests.md
+++ b/claudesprint/prompts/PROMPT_run-tests.md
@@ -43,7 +43,6 @@ When uncertain, default to `implement`.
 For the determined route:
 - Set `step` to `implement` or `fix-tests`
 - Set `current_failures` to verbatim output (truncated ~200 lines)
-- Add to `rationale`: analysis of why routing that way
 - Increment `retry_count`
 
 If `retry_count` > 5, add: "Multiple retries failed - may need human intervention"
@@ -52,6 +51,7 @@ If `retry_count` > 5, add: "Multiple retries failed - may need human interventio
 
 ```bash
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] STEP: run-tests -> <next> (<PASS/FAIL>)" >> .claudesprint/project/current_issue.log
+echo "  Analysis: <why routing to implement or fix-tests>" >> .claudesprint/project/current_issue.log
 ```
 
 ## Rules

--- a/claudesprint/prompts/PROMPT_select-issue.md
+++ b/claudesprint/prompts/PROMPT_select-issue.md
@@ -52,7 +52,6 @@ For selected issue:
   "commands_run": [],
   "current_failures": "",
   "retry_count": 0,
-  "rationale": ["Selected <id> because: <reason>"],
   "context": {
     "acceptance_criteria": "<from details>",
     "category": "<category>"
@@ -64,6 +63,7 @@ For selected issue:
 
 ```bash
 echo "[<ISO>] SELECTED: <id> - <title>" >> .claudesprint/project/current_issue.log
+echo "  Rationale: <why chosen>" >> .claudesprint/project/current_issue.log
 ```
 
 Output summary:

--- a/claudesprint/prompts/PROMPT_stage-changes.md
+++ b/claudesprint/prompts/PROMPT_stage-changes.md
@@ -12,7 +12,7 @@ git status 2>/dev/null || echo "Not a git repo"
 
 If NOT a git repo:
 - Set `step` to `commit-changes` (will skip to complete)
-- Add to `rationale`: "Skipped staging: not a git repository"
+- Log: "Skipped staging: not a git repository"
 - Exit
 
 ## Check Baseline Dirty Files

--- a/claudesprint/prompts/PROMPT_update-docs.md
+++ b/claudesprint/prompts/PROMPT_update-docs.md
@@ -26,7 +26,7 @@ ls -la docs/ 2>/dev/null || echo "No docs directory"
 
 If skipping:
 - Set `step` to `stage-changes`
-- Add to `rationale`: "Skipped docs: <reason>"
+- Log: "Skipped docs: <reason>"
 
 ## Require Docs Update If ANY True:
 
@@ -54,7 +54,6 @@ Guidelines: Clear language, code examples where helpful, follow existing style, 
 
 - Set `step` to `stage-changes`
 - Add to `changes`: doc files created/modified
-- Add to `rationale`: "Updated docs: <summary>" or "Skipped docs: <reason>"
 
 **IMPORTANT**: Preserve existing `changes` array.
 
@@ -63,6 +62,7 @@ Guidelines: Clear language, code examples where helpful, follow existing style, 
 ```bash
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] STEP: update-docs -> stage-changes" >> .claudesprint/project/current_issue.log
 echo "  Docs: <updated/skipped>" >> .claudesprint/project/current_issue.log
+echo "  Decision: <Updated docs: summary OR Skipped docs: reason>" >> .claudesprint/project/current_issue.log
 ```
 
 ## Rules

--- a/claudesprint/prompts/PROMPT_write-tests.md
+++ b/claudesprint/prompts/PROMPT_write-tests.md
@@ -41,13 +41,13 @@ Guidelines:
 - Set `step` to `run-tests`
 - Set `goal` to describe test execution
 - Add to `changes`: `{"path": "<test file>", "summary": "<tests added>"}`
-- Add to `rationale`: test coverage summary
 
 ## Log & Exit
 
 ```bash
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] STEP: write-tests -> run-tests" >> .claudesprint/project/current_issue.log
 echo "  Tests added: <test files>" >> .claudesprint/project/current_issue.log
+echo "  Coverage: <test coverage summary>" >> .claudesprint/project/current_issue.log
 ```
 
 ## Rules

--- a/claudesprint/prompts/_common.md
+++ b/claudesprint/prompts/_common.md
@@ -42,7 +42,8 @@ Required fields to update:
 - `next_action` - specific action for next session
 - `changes` - array of `{path, summary}` for modified files
 - `commands_run` - array of commands executed
-- `rationale` - array of key decisions made
+
+Log key decisions to `current_issue.log` using the Log Progress pattern above.
 
 ## Termination Tokens
 

--- a/claudesprint/schemas/current_issue.schema.json
+++ b/claudesprint/schemas/current_issue.schema.json
@@ -18,8 +18,7 @@
     "changes",
     "commands_run",
     "current_failures",
-    "retry_count",
-    "rationale"
+    "retry_count"
   ],
   "properties": {
     "$schema": {
@@ -126,11 +125,6 @@
       "minimum": 0,
       "default": 0,
       "description": "Number of times the current step has been retried due to failures"
-    },
-    "rationale": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Key decisions made and their reasoning"
     },
     "context": {
       "type": "object",

--- a/claudesprint/services/global_config_service.py
+++ b/claudesprint/services/global_config_service.py
@@ -86,11 +86,6 @@ class DebugConfig(BaseModel):
         default=False,
         description="Log full agent inputs/outputs",
     )
-    max_rationale: int = Field(
-        default=20,
-        ge=5,
-        description="Maximum rationale entries to keep",
-    )
 
 
 class GlobalConfig(BaseModel):
@@ -140,9 +135,6 @@ timeout = 600  # 10 minutes
 [debug]
 # Log full agent inputs/outputs
 conversations = false
-
-# Maximum rationale entries to keep
-max_rationale = 20
 """
 
 
@@ -328,7 +320,6 @@ class GlobalConfigService:
 
         # Flatten debug section
         result["debug_conversations"] = config.debug.conversations
-        result["max_rationale_entries"] = config.debug.max_rationale
 
         return result
 

--- a/claudesprint/tools/cli.py
+++ b/claudesprint/tools/cli.py
@@ -3,7 +3,7 @@
 
 Usage:
     claudesprint-tools issue get
-    claudesprint-tools issue update [--goal=GOAL] [--next-action=ACTION] [--rationale=REASON]
+    claudesprint-tools issue update [--goal=GOAL] [--next-action=ACTION]
     claudesprint-tools issue step <step_name> [--goal=GOAL] [--next-action=ACTION]
     claudesprint-tools issue change <path> <summary>
     claudesprint-tools issue failure <message>
@@ -64,7 +64,6 @@ def cmd_issue_update(args):
     result = update_issue(
         goal=args.goal,
         next_action=args.next_action,
-        add_rationale=args.rationale,
     )
     print(json.dumps(result.to_dict(), indent=2))
 
@@ -170,7 +169,6 @@ def main():
     iupdate_parser = issue_subparsers.add_parser("update", help="Update issue fields")
     iupdate_parser.add_argument("--goal", help="New goal")
     iupdate_parser.add_argument("--next-action", help="New next action")
-    iupdate_parser.add_argument("--rationale", help="Add rationale entry")
     iupdate_parser.set_defaults(func=cmd_issue_update)
 
     # issue step

--- a/claudesprint/tools/issue_tools.py
+++ b/claudesprint/tools/issue_tools.py
@@ -77,7 +77,6 @@ def get_issue() -> ToolResult:
 def update_issue(
     goal: str | None = None,
     next_action: str | None = None,
-    add_rationale: str | None = None,
 ) -> ToolResult:
     """Update current issue fields."""
     try:
@@ -89,16 +88,12 @@ def update_issue(
             data["goal"] = goal
         if next_action is not None:
             data["next_action"] = next_action
-        if add_rationale is not None:
-            rationale = data.get("rationale", [])
-            rationale.append(add_rationale)
-            data["rationale"] = rationale
 
         _save_issue(data)
         return ToolResult(
             success=True,
             message="Issue updated",
-            data={"updated_fields": [k for k, v in [("goal", goal), ("next_action", next_action), ("rationale", add_rationale)] if v is not None]},
+            data={"updated_fields": [k for k, v in [("goal", goal), ("next_action", next_action)] if v is not None]},
         )
     except Exception as e:
         return ToolResult(success=False, message=f"Failed to update issue: {e}")

--- a/claudesprint/validation/current_issue_validator.py
+++ b/claudesprint/validation/current_issue_validator.py
@@ -38,7 +38,6 @@ class CurrentIssueValidator:
         "commands_run",
         "current_failures",
         "retry_count",
-        "rationale",
     ]
 
     def __init__(self, current_issue_path: str | Path) -> None:
@@ -125,7 +124,7 @@ class CurrentIssueValidator:
                 errors.append("repo_state.dirty must be boolean")
 
         # Check array types
-        array_fields = ["changes", "commands_run", "rationale"]
+        array_fields = ["changes", "commands_run"]
         for field_name in array_fields:
             if not isinstance(data.get(field_name), list):
                 errors.append(f"{field_name} must be an array")

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -213,7 +213,6 @@ flowchart TB
         issue_id[issue_id]
         step[step]
         changes[changes]
-        rationale[rationale]
     end
 
     CurrentIssue -->|Execute Steps| Log

--- a/docs/concepts/state-management.md
+++ b/docs/concepts/state-management.md
@@ -156,11 +156,6 @@ Location: `.claudesprint/project/current_issue.json`
 
   "next_action": "Create src/components/Counter.tsx with a functional component that uses useState to manage count",
 
-  "rationale": [
-    "Chose functional component with hooks per project conventions",
-    "Using useState for local state as count doesn't need global state"
-  ],
-
   "retry_count": 0,
 
   "context": {
@@ -186,7 +181,6 @@ Location: `.claudesprint/project/current_issue.json`
 | `commands_run[]` | Commands executed so far |
 | `current_failures` | Error message if in failed state |
 | `next_action` | Specific next step to execute |
-| `rationale[]` | Decisions made and why |
 | `retry_count` | Number of retries on current step |
 | `context` | Cached data from sprint.json |
 
@@ -360,7 +354,7 @@ Don't rely on terminal history or memory. If it's not in `current_issue.json` or
 
 ### 2. Log Decisions
 
-Use `rationale` in `current_issue.json` to capture why decisions were made. This helps future steps understand context.
+Use `current_issue.log` to capture why decisions were made. This helps future steps understand context since the log is injected into agent context.
 
 ### 3. Keep Changes Atomic
 

--- a/docs/concepts/workflow-steps.md
+++ b/docs/concepts/workflow-steps.md
@@ -89,23 +89,21 @@ flowchart TB
 3. Use Context7 (if available) for library documentation
 4. Explore codebase for existing patterns
 5. Identify files to modify or create
-6. Document findings in `rationale`
+6. Document findings in `context` and session log
 
 **Output State**:
 ```json
 {
   "step": "implement",
-  "rationale": [
-    "Found existing Button component pattern in src/components/Button.tsx",
-    "React Testing Library already configured for component tests",
-    "Will create Counter.tsx following Button.tsx structure"
-  ],
+  "context": {
+    "external_docs_findings": "Found Button component pattern, RTL configured. Will create Counter.tsx following Button.tsx structure"
+  },
   "next_action": "Create Counter component with useState hook for count state"
 }
 ```
 
 **Failure Modes**:
-- Missing critical documentation → Proceed with best effort, note in rationale
+- Missing critical documentation → Proceed with best effort, log decision
 - Context7 unavailable → Continue without library docs
 
 ---
@@ -116,11 +114,11 @@ flowchart TB
 
 **Input State**:
 - `current_issue.json` with `step: "implement"`
-- `rationale` from read-docs step
+- `context` from read-docs step
 
 **Agent Behavior**:
 1. Review acceptance criteria
-2. Review rationale and identified patterns
+2. Review context and session log for identified patterns
 3. Make minimal code changes:
    - Create new files as needed
    - Modify existing files carefully
@@ -148,7 +146,7 @@ flowchart TB
 
 **Failure Modes**:
 - Missing dependencies → Note in `current_failures`, may need different issue first
-- Unclear requirements → Document assumptions in `rationale`
+- Unclear requirements → Document assumptions in session log
 
 ---
 
@@ -188,7 +186,7 @@ flowchart LR
 
 **Failure Modes**:
 - Tests already exist → Verify coverage, update if needed
-- Unclear how to test → Document limitation in rationale
+- Unclear how to test → Document limitation in session log
 
 ---
 
@@ -261,8 +259,7 @@ flowchart TB
 ```json
 {
   "step": "run-tests",
-  "current_failures": "",
-  "rationale": ["Test was correct, fixed useState initial value in Counter.tsx"]
+  "current_failures": ""
 }
 ```
 
@@ -270,8 +267,7 @@ flowchart TB
 ```json
 {
   "step": "implement",
-  "current_failures": "Implementation missing required feature",
-  "rationale": ["Code doesn't handle edge case specified in acceptance criteria"]
+  "current_failures": "Implementation missing required feature"
 }
 ```
 
@@ -311,16 +307,14 @@ agent-browser close
 **Output State (Pass)**:
 ```json
 {
-  "step": "code-review",
-  "rationale": ["Browser validation passed, count increments correctly"]
+  "step": "code-review"
 }
 ```
 
 **Output State (Skip)**:
 ```json
 {
-  "step": "code-review",
-  "rationale": ["Skipped browser validation - API-only issue"]
+  "step": "code-review"
 }
 ```
 
@@ -355,8 +349,7 @@ agent-browser close
 **Output State (Pass)**:
 ```json
 {
-  "step": "update-docs",
-  "rationale": ["Code review passed - all acceptance criteria verified"]
+  "step": "update-docs"
 }
 ```
 
@@ -364,8 +357,7 @@ agent-browser close
 ```json
 {
   "step": "fix-code-review-issues",
-  "current_failures": "Missing validation for negative count values",
-  "rationale": ["Acceptance criterion 'Count should not go below 0' not implemented"]
+  "current_failures": "Missing validation for negative count values"
 }
 ```
 

--- a/docs/development/prompt-engineering.md
+++ b/docs/development/prompt-engineering.md
@@ -100,7 +100,7 @@ Ensures prerequisites are met before proceeding:
 ## Pre-flight Checks
 1. Read current_issue.json - verify step is "implement"
 2. Read sprint.json - verify issue exists and is in_progress
-3. Check that read-docs completed (rationale has entries)
+3. Check that read-docs completed (context has findings)
 ```
 
 #### Instructions
@@ -111,8 +111,8 @@ Step-by-step guidance:
 ## Instructions
 
 1. Read the acceptance criteria from context.acceptance_criteria
-2. Review the rationale from the read-docs step
-3. Identify files to modify based on rationale
+2. Review the context from the read-docs step
+3. Identify files to modify based on context and session log
 4. Make minimal code changes:
    - Follow existing patterns
    - Don't add unrequested features
@@ -127,7 +127,7 @@ Explicit boundaries:
 
 ```markdown
 ## DO
-- Follow patterns from files mentioned in rationale
+- Follow patterns from files mentioned in context/session log
 - Make the minimum changes to satisfy criteria
 - Record all changes in current_issue.json
 
@@ -242,8 +242,8 @@ Reference values from `current_issue.json`:
 2. Check issue category:
    ${context.category}
 
-3. Consider previous rationale:
-   ${rationale}
+3. Consider previous context:
+   ${context}
 ```
 
 ### Conditional Sections
@@ -279,7 +279,7 @@ Review each acceptance criterion and verify:
 1. Code implements the criterion exactly
 2. No additional functionality was added
 3. Tests exist for the criterion
-4. Code follows patterns in rationale
+4. Code follows patterns from context
 ```
 
 ### 2. Use Checklists
@@ -343,8 +343,8 @@ Update current_issue.json with:
 - `step`: "write-tests"
 - `changes`: Add all files modified
 - `commands_run`: Add any commands executed
-- `rationale`: Add any decisions made
 - `current_failures`: Clear if previously set
+- Log key decisions to `current_issue.log`
 ```
 
 ## Testing Prompt Changes

--- a/docs/guides/prompt-customization.md
+++ b/docs/guides/prompt-customization.md
@@ -172,7 +172,7 @@ Additional details...
 - Set `step` to `next-step`
 - Set `goal` to describe next action
 - Add to `changes`: modified files
-- Add to `rationale`: key decisions
+- Log key decisions to `current_issue.log`
 
 ## Log & Exit
 

--- a/docs/reference/schema-reference.md
+++ b/docs/reference/schema-reference.md
@@ -336,10 +336,6 @@ The current issue file contains all context for the active workflow step.
     "next_action": {
       "type": "string"
     },
-    "rationale": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
     "retry_count": {
       "type": "integer",
       "minimum": 0
@@ -370,7 +366,6 @@ The current issue file contains all context for the active workflow step.
 | `commands_run` | array | No | Commands executed |
 | `current_failures` | string | No | Error message if failed |
 | `next_action` | string | No | Next action to take |
-| `rationale` | array | No | Decisions and reasoning |
 | `retry_count` | integer | No | Retry attempts on current step |
 | `context` | object | Yes | Issue context from sprint |
 
@@ -457,11 +452,6 @@ The current issue file contains all context for the active workflow step.
   "commands_run": [],
   "current_failures": "",
   "next_action": "Create src/components/Counter.tsx with functional component using useState",
-  "rationale": [
-    "Using functional component with hooks per project conventions",
-    "useState for local state - count doesn't need global state",
-    "Following Button.tsx pattern for component structure"
-  ],
   "retry_count": 0,
   "context": {
     "acceptance_criteria": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,6 @@ def sample_current_issue_dict():
         "changes": [],
         "commands_run": [],
         "current_failures": "",
-        "rationale": [],
         "retry_count": 0,
     }
 

--- a/tests/test_global_config_service.py
+++ b/tests/test_global_config_service.py
@@ -46,7 +46,6 @@ class TestGlobalConfigModels:
         """Test DebugConfig has expected defaults."""
         config = DebugConfig()
         assert config.conversations is False
-        assert config.max_rationale == 20
 
     def test_global_config_defaults(self) -> None:
         """Test GlobalConfig composes all sections."""


### PR DESCRIPTION
## Summary
- Remove `rationale` array field from `current_issue.json` schema and model
- Remove `max_rationale_entries` config option and `prune_rationale()` method
- Update all prompts to log decisions to `current_issue.log` instead
- Maintain backward compatibility with empty `rationale: []` in serialization

## Motivation
The `rationale` array grew unbounded during debugging loops (fix-tests cycling 5+ times), consuming context window tokens. Since the session log is already injected into agent context and provides timestamped decision history, storing rationale separately was redundant.

## Changes
- **Models**: Remove `rationale` field, `prune_rationale()`, update `prune_arrays()`
- **Config**: Remove `max_rationale_entries` from config and global settings
- **CLI/Tools**: Remove `--rationale` argument from `claudesprint-tools issue update`
- **Prompts**: Replace "Add to rationale" with "Log: Decision:" pattern (12 files)
- **Schema**: Remove `rationale` from required fields and properties
- **Docs**: Update to reflect log-based decision tracking

## Migration
Existing `current_issue.json` files with `rationale` data will continue to validate but the field is ignored. New files won't include it