### PR TITLE
Refactor status tokens to XML tags for robust LLM output parsing

### DIFF
--- a/claudesprint/core/issue_engine.py
+++ b/claudesprint/core/issue_engine.py
@@ -119,45 +119,45 @@ class IssueEngine:
     }
 
     # Patterns for parsing step output to determine routing
-    # These patterns match STATUS tokens that signal routing decisions.
-    # No end-of-string anchor ($) is used because LLMs may add trailing text/newlines.
+    # These patterns match <status>...</status> XML tags that signal routing decisions.
+    # XML tags are preferred over plain text markers for more robust LLM output parsing.
     OUTPUT_PATTERNS = {
         IssueStep.RUN_TESTS: {
             "pass": [
-                r"STATUS:\s*PASS\s*",
+                r"<status>\s*pass\s*</status>",
             ],
             "fail_code": [
-                r"STATUS:\s*FAIL_CODE\s*",
+                r"<status>\s*fail_code\s*</status>",
             ],
             "fail_test": [
-                r"STATUS:\s*FAIL_TEST\s*",
+                r"<status>\s*fail_test\s*</status>",
             ],
         },
         IssueStep.FIX_TESTS: {
             "code_wrong": [
-                r"STATUS:\s*CODE_WRONG\s*",
+                r"<status>\s*code_wrong\s*</status>",
             ],
             "test_fixed": [
-                r"STATUS:\s*TEST_FIXED\s*",
+                r"<status>\s*test_fixed\s*</status>",
             ],
         },
         IssueStep.BROWSER_VALIDATION: {
             "skip": [
-                r"STATUS:\s*SKIP\s*",
+                r"<status>\s*skip\s*</status>",
             ],
             "fail": [
-                r"STATUS:\s*FAIL\s*",
+                r"<status>\s*fail\s*</status>",
             ],
             "pass": [
-                r"STATUS:\s*PASS\s*",
+                r"<status>\s*pass\s*</status>",
             ],
         },
         IssueStep.CODE_REVIEW: {
             "issues": [
-                r"STATUS:\s*ISSUES\s*",
+                r"<status>\s*issues\s*</status>",
             ],
             "pass": [
-                r"STATUS:\s*PASS\s*",
+                r"<status>\s*pass\s*</status>",
             ],
         },
     }

--- a/claudesprint/prompts/PROMPT_browser-validation.md
+++ b/claudesprint/prompts/PROMPT_browser-validation.md
@@ -7,7 +7,7 @@ The `agent-browser` tool is not installed globally. Skip this step:
 - Set `step` to `code-review`
 - Log: "Skipped browser validation: agent-browser not available"
 
-STATUS: SKIP
+<status>skip</status>
 {% else %}
 You are a **browser validation agent**. Validate UI features using agent-browser for e2e testing.
 
@@ -94,10 +94,10 @@ echo "  Result: <PASS/FAIL/SKIP>" >> .claudesprint/project/current_issue.log
 - Always close browser session
 - Take screenshots as evidence
 
-## Termination Token (REQUIRED)
+## Termination Tag (REQUIRED)
 
-Last line must be exactly one of:
-- `STATUS: PASS`
-- `STATUS: FAIL`
-- `STATUS: SKIP`
+End your response with exactly one of:
+- `<status>pass</status>` - all UI validations passed
+- `<status>fail</status>` - UI validation failed
+- `<status>skip</status>` - no UI components to validate
 {% endif %}

--- a/claudesprint/prompts/PROMPT_code-review.md
+++ b/claudesprint/prompts/PROMPT_code-review.md
@@ -65,8 +65,8 @@ echo "  Decision: <Code review passed: all AC verified OR blocking issues found>
 - Be objective - don't approve just to move forward
 - List ALL blocking issues
 
-## Termination Token (REQUIRED)
+## Termination Tag (REQUIRED)
 
-Last line must be exactly one of:
-- `STATUS: PASS`
-- `STATUS: ISSUES`
+End your response with exactly one of:
+- `<status>pass</status>` - code review passed
+- `<status>issues</status>` - blocking issues found

--- a/claudesprint/prompts/PROMPT_fix-tests.md
+++ b/claudesprint/prompts/PROMPT_fix-tests.md
@@ -61,8 +61,8 @@ echo "  Decision: <Fixed test: what was wrong OR Re-routing: test expects X, imp
 - Do NOT weaken tests to make them pass
 - If implementation wrong, re-route to `implement`
 
-## Termination Token (REQUIRED)
+## Termination Tag (REQUIRED)
 
-Last line must be exactly one of:
-- `STATUS: TEST_FIXED`
-- `STATUS: CODE_WRONG`
+End your response with exactly one of:
+- `<status>test_fixed</status>` - test was fixed, ready to re-run
+- `<status>code_wrong</status>` - code needs fixing, not the test

--- a/claudesprint/prompts/PROMPT_run-tests.md
+++ b/claudesprint/prompts/PROMPT_run-tests.md
@@ -60,9 +60,9 @@ echo "  Analysis: <why routing to implement or fix-tests>" >> .claudesprint/proj
 - Do NOT commit changes
 - Include verbatim failure output
 
-## Termination Token (REQUIRED)
+## Termination Tag (REQUIRED)
 
-Last line must be exactly one of:
-- `STATUS: PASS`
-- `STATUS: FAIL_CODE`
-- `STATUS: FAIL_TEST`
+End your response with exactly one of:
+- `<status>pass</status>` - all tests passed
+- `<status>fail_code</status>` - tests fail due to code bug
+- `<status>fail_test</status>` - tests fail due to test bug

--- a/claudesprint/prompts/_common.md
+++ b/claudesprint/prompts/_common.md
@@ -45,13 +45,13 @@ Required fields to update:
 
 Log key decisions to `current_issue.log` using the Log Progress pattern above.
 
-## Termination Tokens
+## Termination Tags
 
-Some steps require a termination token as the last line:
-- `STATUS: PASS` - step succeeded
-- `STATUS: FAIL` / `STATUS: FAIL_CODE` / `STATUS: FAIL_TEST` - step failed
-- `STATUS: SKIP` - step skipped (not applicable)
-- `STATUS: ISSUES` - issues found (code review)
+Some steps require a status tag as the final output:
+- `<status>pass</status>` - step succeeded
+- `<status>fail</status>` / `<status>fail_code</status>` / `<status>fail_test</status>` - step failed
+- `<status>skip</status>` - step skipped (not applicable)
+- `<status>issues</status>` - issues found (code review)
 
 ## Session Rules
 

--- a/docs/guides/prompt-customization.md
+++ b/docs/guides/prompt-customization.md
@@ -187,18 +187,18 @@ echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] STEP: my-custom-step -> next-step" >> .cl
 - [Important constraint]
 ```
 
-### Termination Tokens
+### Termination Tags
 
-Some steps use termination tokens to signal outcomes:
+Some steps use XML status tags to signal outcomes:
 
-| Token | Meaning |
-|-------|---------|
-| `STATUS: PASS` | Step completed successfully |
-| `STATUS: FAIL` | Step failed (generic) |
-| `STATUS: FAIL_CODE` | Code bug detected |
-| `STATUS: FAIL_TEST` | Test bug detected |
-| `STATUS: SKIP` | Step skipped (not applicable) |
-| `STATUS: ISSUES` | Issues found requiring fixes |
+| Tag | Meaning |
+|-----|---------|
+| `<status>pass</status>` | Step completed successfully |
+| `<status>fail</status>` | Step failed (generic) |
+| `<status>fail_code</status>` | Code bug detected |
+| `<status>fail_test</status>` | Test bug detected |
+| `<status>skip</status>` | Step skipped (not applicable) |
+| `<status>issues</status>` | Issues found requiring fixes |
 
 ## Common Customizations
 

--- a/tests/test_prompt_service.py
+++ b/tests/test_prompt_service.py
@@ -301,7 +301,7 @@ class TestPromptServiceTemplateRendering:
 ## SKIP Section
 
 This is a multiline skip notice.
-STATUS: SKIP
+<status>skip</status>
 {% endif %}
 
 ## Main Content
@@ -314,7 +314,7 @@ Rest of prompt."""
 
         content = service.get_prompt_content("test")
         assert "## SKIP Section" in content
-        assert "STATUS: SKIP" in content
+        assert "<status>skip</status>" in content
         assert "## Main Content" in content
 
     def test_render_false_returns_raw(


### PR DESCRIPTION
# Summary

Replace plain text `STATUS: X` markers with XML `<status>x</status>` tags for routing decisions. Update regex patterns in issue engine to match new XML format. Update all prompt templates and documentation to use consistent tag format.

# Motivation

XML tags are more robust for LLM output parsing because they're less likely to appear accidentally in prose, provide unambiguous delimiters with opening/closing tags, and are easier to extract programmatically.

# Changes

| File | Change |
|------|--------|
| `issue_engine.py` | Updated OUTPUT_PATTERNS regex |
| `PROMPT_*.md` | Updated termination instructions |
| `_common.md` | Updated shared documentation |
| `prompt-customization.md` | Updated guide |
| `test_prompt_service.py` | Updated test expectations |

# Test plan

- [x] Existing tests pass with updated format
- [ ] Manual test: run issue workflow and verify status parsing works