### PR TITLE
feat: Add ClaudeSprint CLI skill for Claude Code integration

### DIFF
--- a/.claude/skills/claudesprint/SKILL.md
+++ b/.claude/skills/claudesprint/SKILL.md
@@ -1,51 +1,4 @@
-"""Constants for ClaudeSprint services."""
-
-__all__ = ["PROMPTS_README_CONTENT", "CLAUDESPRINT_SKILL_CONTENT"]
-
-# Content for the prompts README file
-PROMPTS_README_CONTENT = """# Prompt Overrides
-
-This directory allows you to customize ClaudeSprint prompts for your project.
-
-## How It Works
-
-To override a built-in prompt, create a file with the same name in this directory.
-ClaudeSprint checks this directory first before falling back to built-in prompts.
-
-## Available Prompts
-
-- `PROMPT_init.xml.j2` - Sprint initialization from spec
-- `PROMPT_plan.xml.j2` - Planning mode
-- `PROMPT_select-issue.xml.j2` - Issue selection step
-- `PROMPT_read-docs.xml.j2` - Documentation reading step
-- `PROMPT_implement.xml.j2` - Implementation step
-- `PROMPT_write-tests.xml.j2` - Test writing step
-- `PROMPT_run-tests.xml.j2` - Test execution step
-- `PROMPT_fix-tests.xml.j2` - Test fixing step
-- `PROMPT_browser-validation.xml.j2` - Browser QA step
-- `PROMPT_code-review.xml.j2` - Code review step
-- `PROMPT_fix-code-review-issues.xml.j2` - Code review fixes
-- `PROMPT_update-docs.xml.j2` - Documentation updates
-- `PROMPT_stage-changes.xml.j2` - Stage changes step
-- `PROMPT_commit-changes.xml.j2` - Commit changes step
-
-## Example
-
-To customize the implementation prompt:
-
-1. Copy the built-in prompt (or create from scratch)
-2. Save as `.claudesprint/prompts/PROMPT_implement.xml.j2`
-3. ClaudeSprint will use your version instead
-
-## Notes
-
-- Keep the same structure and required sections
-- Test changes with a single issue before using in production
-- You can delete override files to revert to built-in behavior
-"""
-
-# Content for the ClaudeSprint skill file
-CLAUDESPRINT_SKILL_CONTENT = """---
+---
 name: claudesprint
 description: Orchestrates autonomous development sprints using ClaudeSprint. Use when the user needs to: initialize or run development sprints, manage sprint issues, track workflow progress, check sprint status, or coordinate multi-step autonomous development tasks.
 allowed-tools: Bash(claudesprint:*)
@@ -242,4 +195,3 @@ claudesprint run --debug-conversations
 # Environment check
 claudesprint doctor -v
 ```
-"""

--- a/.claude/skills/claudesprint/SKILL.md
+++ b/.claude/skills/claudesprint/SKILL.md
@@ -41,7 +41,7 @@ claudesprint run -v                     # Verbose output
 claudesprint run -vv                    # Debug output
 claudesprint status                     # Show sprint and issue status
 claudesprint status --spec SPEC_01      # Status for specific sprint
-claudesprint sprints                    # List all available sprints
+claudesprint-tools sprints                    # List all available sprints
 claudesprint validate                   # Validate sprint.json structure
 claudesprint reset                      # Clear current issue state
 ```
@@ -59,33 +59,33 @@ These commands are used by agents during workflow execution:
 
 ```bash
 # Get current issue state
-claudesprint issue get
+claudesprint-tools issue get
 
 # Initialize issue state
-claudesprint issue init <issue_id>
-claudesprint issue init ISSUE_01 --step implement
-claudesprint issue init ISSUE_01 --goal "Add login feature"
+claudesprint-tools issue init <issue_id>
+claudesprint-tools issue init ISSUE_01 --step implement
+claudesprint-tools issue init ISSUE_01 --goal "Add login feature"
 
 # Update issue fields
-claudesprint issue update --goal "New goal"
-claudesprint issue update --next-action "Write tests"
+claudesprint-tools issue update --goal "New goal"
+claudesprint-tools issue update --next-action "Write tests"
 
 # Set next workflow step
-claudesprint issue step <step_name>
-claudesprint issue step implement --goal "Build feature"
-claudesprint issue step run-tests --clear-failures
+claudesprint-tools issue step <step_name>
+claudesprint-tools issue step implement --goal "Build feature"
+claudesprint-tools issue step run-tests --clear-failures
 
 # Record file changes
-claudesprint issue change <path> <summary>
-claudesprint issue change src/auth.py "Added login endpoint"
+claudesprint-tools issue change <path> <summary>
+claudesprint-tools issue change src/auth.py "Added login endpoint"
 
 # Record failures
-claudesprint issue failure <message>
-claudesprint issue failure "Tests failed: 2 assertions"
-claudesprint issue failure "Timeout" --no-increment
+claudesprint-tools issue failure <message>
+claudesprint-tools issue failure "Tests failed: 2 assertions"
+claudesprint-tools issue failure "Timeout" --no-increment
 
 # Clear failures and retry count
-claudesprint issue clear-failures
+claudesprint-tools issue clear-failures
 ```
 
 ## Commands - Sprint Queries (agent tools)
@@ -94,16 +94,16 @@ Token-optimized queries for agents:
 
 ```bash
 # List available issues (compact view)
-claudesprint sprint available
-claudesprint sprint available --spec SPEC_01
+claudesprint-tools sprint available
+claudesprint-tools sprint available --spec SPEC_01
 
 # Start working on an issue
-claudesprint sprint start <issue_id>
-claudesprint sprint start ISSUE_03 --spec SPEC_01
+claudesprint-tools sprint start <issue_id>
+claudesprint-tools sprint start ISSUE_03 --spec SPEC_01
 
 # Get full issue details
-claudesprint sprint details <issue_id>
-claudesprint sprint details ISSUE_03 --spec SPEC_01
+claudesprint-tools sprint details <issue_id>
+claudesprint-tools sprint details ISSUE_03 --spec SPEC_01
 ```
 
 ## Commands - Configuration
@@ -153,29 +153,29 @@ claudesprint status
 
 ```bash
 # Agent navigating through workflow steps
-claudesprint issue step read-docs --goal "Understand requirements"
-claudesprint issue step explore --goal "Map codebase structure"
-claudesprint issue step plan --goal "Design implementation"
-claudesprint issue step implement --goal "Write the feature"
-claudesprint issue step write-tests --goal "Add test coverage"
-claudesprint issue step run-tests
-claudesprint issue step stage-changes
-claudesprint issue step commit-changes
-claudesprint issue step complete
+claudesprint-tools issue step read-docs --goal "Understand requirements"
+claudesprint-tools issue step explore --goal "Map codebase structure"
+claudesprint-tools issue step plan --goal "Design implementation"
+claudesprint-tools issue step implement --goal "Write the feature"
+claudesprint-tools issue step write-tests --goal "Add test coverage"
+claudesprint-tools issue step run-tests
+claudesprint-tools issue step stage-changes
+claudesprint-tools issue step commit-changes
+claudesprint-tools issue step complete
 ```
 
 ### Failure recovery
 
 ```bash
 # Record a test failure
-claudesprint issue failure "AssertionError in test_login"
+claudesprint-tools issue failure "AssertionError in test_login"
 
 # Check current state
-claudesprint issue get
+claudesprint-tools issue get
 
 # After fixing, clear failures and continue
-claudesprint issue clear-failures
-claudesprint issue step run-tests
+claudesprint-tools issue clear-failures
+claudesprint-tools issue step run-tests
 ```
 
 ## Debugging

--- a/claudesprint/services/constants.py
+++ b/claudesprint/services/constants.py
@@ -88,7 +88,7 @@ claudesprint run -v                     # Verbose output
 claudesprint run -vv                    # Debug output
 claudesprint status                     # Show sprint and issue status
 claudesprint status --spec SPEC_01      # Status for specific sprint
-claudesprint sprints                    # List all available sprints
+claudesprint-tools sprints                    # List all available sprints
 claudesprint validate                   # Validate sprint.json structure
 claudesprint reset                      # Clear current issue state
 ```
@@ -106,33 +106,33 @@ These commands are used by agents during workflow execution:
 
 ```bash
 # Get current issue state
-claudesprint issue get
+claudesprint-tools issue get
 
 # Initialize issue state
-claudesprint issue init <issue_id>
-claudesprint issue init ISSUE_01 --step implement
-claudesprint issue init ISSUE_01 --goal "Add login feature"
+claudesprint-tools issue init <issue_id>
+claudesprint-tools issue init ISSUE_01 --step implement
+claudesprint-tools issue init ISSUE_01 --goal "Add login feature"
 
 # Update issue fields
-claudesprint issue update --goal "New goal"
-claudesprint issue update --next-action "Write tests"
+claudesprint-tools issue update --goal "New goal"
+claudesprint-tools issue update --next-action "Write tests"
 
 # Set next workflow step
-claudesprint issue step <step_name>
-claudesprint issue step implement --goal "Build feature"
-claudesprint issue step run-tests --clear-failures
+claudesprint-tools issue step <step_name>
+claudesprint-tools issue step implement --goal "Build feature"
+claudesprint-tools issue step run-tests --clear-failures
 
 # Record file changes
-claudesprint issue change <path> <summary>
-claudesprint issue change src/auth.py "Added login endpoint"
+claudesprint-tools issue change <path> <summary>
+claudesprint-tools issue change src/auth.py "Added login endpoint"
 
 # Record failures
-claudesprint issue failure <message>
-claudesprint issue failure "Tests failed: 2 assertions"
-claudesprint issue failure "Timeout" --no-increment
+claudesprint-tools issue failure <message>
+claudesprint-tools issue failure "Tests failed: 2 assertions"
+claudesprint-tools issue failure "Timeout" --no-increment
 
 # Clear failures and retry count
-claudesprint issue clear-failures
+claudesprint-tools issue clear-failures
 ```
 
 ## Commands - Sprint Queries (agent tools)
@@ -141,16 +141,16 @@ Token-optimized queries for agents:
 
 ```bash
 # List available issues (compact view)
-claudesprint sprint available
-claudesprint sprint available --spec SPEC_01
+claudesprint-tools sprint available
+claudesprint-tools sprint available --spec SPEC_01
 
 # Start working on an issue
-claudesprint sprint start <issue_id>
-claudesprint sprint start ISSUE_03 --spec SPEC_01
+claudesprint-tools sprint start <issue_id>
+claudesprint-tools sprint start ISSUE_03 --spec SPEC_01
 
 # Get full issue details
-claudesprint sprint details <issue_id>
-claudesprint sprint details ISSUE_03 --spec SPEC_01
+claudesprint-tools sprint details <issue_id>
+claudesprint-tools sprint details ISSUE_03 --spec SPEC_01
 ```
 
 ## Commands - Configuration
@@ -200,29 +200,29 @@ claudesprint status
 
 ```bash
 # Agent navigating through workflow steps
-claudesprint issue step read-docs --goal "Understand requirements"
-claudesprint issue step explore --goal "Map codebase structure"
-claudesprint issue step plan --goal "Design implementation"
-claudesprint issue step implement --goal "Write the feature"
-claudesprint issue step write-tests --goal "Add test coverage"
-claudesprint issue step run-tests
-claudesprint issue step stage-changes
-claudesprint issue step commit-changes
-claudesprint issue step complete
+claudesprint-tools issue step read-docs --goal "Understand requirements"
+claudesprint-tools issue step explore --goal "Map codebase structure"
+claudesprint-tools issue step plan --goal "Design implementation"
+claudesprint-tools issue step implement --goal "Write the feature"
+claudesprint-tools issue step write-tests --goal "Add test coverage"
+claudesprint-tools issue step run-tests
+claudesprint-tools issue step stage-changes
+claudesprint-tools issue step commit-changes
+claudesprint-tools issue step complete
 ```
 
 ### Failure recovery
 
 ```bash
 # Record a test failure
-claudesprint issue failure "AssertionError in test_login"
+claudesprint-tools issue failure "AssertionError in test_login"
 
 # Check current state
-claudesprint issue get
+claudesprint-tools issue get
 
 # After fixing, clear failures and continue
-claudesprint issue clear-failures
-claudesprint issue step run-tests
+claudesprint-tools issue clear-failures
+claudesprint-tools issue step run-tests
 ```
 
 ## Debugging

--- a/claudesprint/services/init_repo_service.py
+++ b/claudesprint/services/init_repo_service.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from claudesprint.services.constants import PROMPTS_README_CONTENT
+from claudesprint.services.constants import CLAUDESPRINT_SKILL_CONTENT, PROMPTS_README_CONTENT
 from claudesprint.services.git_service import GitService
 from claudesprint.services.project_config_service import DEFAULT_PROJECT_CONFIG_TOML
 
@@ -31,6 +31,12 @@ class InitRepoService:
     CONFIG_FILE = "config.toml"
     GITIGNORE_ENTRY = ".claudesprint/"
 
+    # Skill installation paths
+    CLAUDE_DIR = ".claude"
+    SKILLS_DIR = "skills"
+    SKILL_NAME = "claudesprint"
+    SKILL_FILE = "SKILL.md"
+
     def __init__(self, project_root: str | Path) -> None:
         """Initialize the service.
 
@@ -44,6 +50,12 @@ class InitRepoService:
         self.prompts_readme = self.prompts_dir / self.PROMPTS_README
         self.config_file = self.claudesprint_dir / self.CONFIG_FILE
         self.gitignore_path = self.project_root / ".gitignore"
+
+        # Skill paths
+        self.claude_dir = self.project_root / self.CLAUDE_DIR
+        self.skills_dir = self.claude_dir / self.SKILLS_DIR
+        self.skill_dir = self.skills_dir / self.SKILL_NAME
+        self.skill_file = self.skill_dir / self.SKILL_FILE
 
     def exists(self) -> bool:
         """Check if .claudesprint/ directory already exists.
@@ -117,6 +129,20 @@ class InitRepoService:
                     result.created_files.append(".gitignore")
                 else:
                     result.created_files.append(".gitignore (updated)")
+
+            # Create skill directory and file
+            skill_dir_existed = self.skill_dir.exists()
+            self.skill_dir.mkdir(parents=True, exist_ok=True)
+            if not skill_dir_existed:
+                result.created_dirs.append(
+                    f"{self.CLAUDE_DIR}/{self.SKILLS_DIR}/{self.SKILL_NAME}/"
+                )
+
+            if not self.skill_file.exists() or force:
+                self.skill_file.write_text(CLAUDESPRINT_SKILL_CONTENT)
+                result.created_files.append(
+                    f"{self.CLAUDE_DIR}/{self.SKILLS_DIR}/{self.SKILL_NAME}/{self.SKILL_FILE}"
+                )
 
         except OSError as e:
             return InitRepoResult(

--- a/tests/test_init_repo_service.py
+++ b/tests/test_init_repo_service.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from claudesprint.services.constants import PROMPTS_README_CONTENT
+from claudesprint.services.constants import CLAUDESPRINT_SKILL_CONTENT, PROMPTS_README_CONTENT
 from claudesprint.services.init_repo_service import (
     InitRepoService,
     InitRepoResult,
@@ -297,6 +297,101 @@ class TestInitRepoServiceOSError:
             assert result.success is False
             assert "Failed to create directory structure" in result.error
             assert "Disk full" in result.error
+
+
+class TestInitRepoServiceSkill:
+    """Tests for Claude Code skill creation."""
+
+    def test_creates_skill_directory_and_file(self) -> None:
+        """Test init creates .claude/skills/claudesprint/SKILL.md."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            service = InitRepoService(tmpdir)
+            result = service.init()
+
+            assert result.success is True
+            skill_path = Path(tmpdir) / ".claude" / "skills" / "claudesprint" / "SKILL.md"
+            assert skill_path.exists()
+            assert skill_path.read_text() == CLAUDESPRINT_SKILL_CONTENT
+
+    def test_skill_in_created_items(self) -> None:
+        """Test skill directory and file are listed in result."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            service = InitRepoService(tmpdir)
+            result = service.init()
+
+            assert result.success is True
+            assert ".claude/skills/claudesprint/" in result.created_dirs
+            assert ".claude/skills/claudesprint/SKILL.md" in result.created_files
+
+    def test_force_overwrites_skill(self) -> None:
+        """Test --force overwrites SKILL.md."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create initial structure with custom skill
+            skill_dir = Path(tmpdir) / ".claude" / "skills" / "claudesprint"
+            skill_dir.mkdir(parents=True)
+            skill_path = skill_dir / "SKILL.md"
+            skill_path.write_text("# Custom skill content")
+
+            # Also create .claudesprint to satisfy exists check
+            (Path(tmpdir) / ".claudesprint").mkdir()
+
+            service = InitRepoService(tmpdir)
+            result = service.init(force=True)
+
+            assert result.success is True
+            assert skill_path.read_text() == CLAUDESPRINT_SKILL_CONTENT
+
+    def test_preserves_skill_if_exists_without_force(self) -> None:
+        """Test init preserves existing SKILL.md when --force is not used."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create skill file and .claudesprint to satisfy exists check
+            skill_dir = Path(tmpdir) / ".claude" / "skills" / "claudesprint"
+            skill_dir.mkdir(parents=True)
+            skill_path = skill_dir / "SKILL.md"
+            skill_path.write_text("# Custom skill content")
+            (Path(tmpdir) / ".claudesprint").mkdir()
+
+            service = InitRepoService(tmpdir)
+            # Without force, init fails because .claudesprint exists
+            result = service.init(force=False)
+
+            assert result.success is False
+            # Skill file should be preserved since init failed
+            assert skill_path.read_text() == "# Custom skill content"
+
+    def test_skill_dir_not_listed_if_already_exists(self) -> None:
+        """Test skill directory not listed as created if it already exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create skill directory first
+            skill_dir = Path(tmpdir) / ".claude" / "skills" / "claudesprint"
+            skill_dir.mkdir(parents=True)
+
+            service = InitRepoService(tmpdir)
+            result = service.init()
+
+            assert result.success is True
+            # Directory already existed, so not in created_dirs
+            assert ".claude/skills/claudesprint/" not in result.created_dirs
+            # But file is still created
+            assert ".claude/skills/claudesprint/SKILL.md" in result.created_files
+
+    def test_does_not_overwrite_existing_skill_without_force(self) -> None:
+        """Test init does not overwrite existing SKILL.md when force=False."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create skill file but NOT .claudesprint
+            skill_dir = Path(tmpdir) / ".claude" / "skills" / "claudesprint"
+            skill_dir.mkdir(parents=True)
+            skill_path = skill_dir / "SKILL.md"
+            skill_path.write_text("# Custom skill content")
+
+            service = InitRepoService(tmpdir)
+            result = service.init(force=False)
+
+            assert result.success is True
+            # Skill file should NOT be overwritten
+            assert skill_path.read_text() == "# Custom skill content"
+            # Skill file should NOT be in created_files (wasn't created)
+            assert ".claude/skills/claudesprint/SKILL.md" not in result.created_files
 
 
 class TestInitRepoResult:


### PR DESCRIPTION
## Summary

- Add Claude Code skill at `.claude/skills/claudesprint/SKILL.md` with comprehensive CLI documentation
- Integrate skill creation into `initrepo` command so users automatically get the skill
- Add `CLAUDESPRINT_SKILL_CONTENT` constant for embedding skill content
- Add 6 test cases covering skill creation functionality

## Changes

The skill provides Claude Code with knowledge of all ClaudeSprint commands:
- Sprint lifecycle (`init`, `run`, `status`, `validate`, `reset`)
- Planning (`plan`)
- Issue management (`issue get/init/update/step/change/failure`)
- Sprint queries (`sprint available/start/details`)
- Configuration (`config path/init/show/edit`, `models`)
- Diagnostics (`doctor`)

## Test plan

- [x] All 28 `test_init_repo_service.py` tests pass
- [x] Skill file content matches embedded constant
- [x] `initrepo` creates skill at correct path
- [ ] Verify skill appears in Claude Code's available skills list

🤖 Generated with [Claude Code](https://claude.com/claude-code)