### PR TITLE
refactor: Asyncio-based ClaudeRunner and HeartbeatService

### DIFF
--- a/claudesprint/core/claude_runner.py
+++ b/claudesprint/core/claude_runner.py
@@ -8,7 +8,8 @@ import signal
 import subprocess
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 from typing import AsyncIterator, Callable, Optional
 
@@ -19,6 +20,16 @@ from claudesprint.utils.process_manager import get_process_manager
 logger = logging.getLogger(__name__)
 
 
+class FailureCategory(StrEnum):
+    """Categories of failure for Claude CLI execution."""
+
+    NONE = "none"  # Success (exit_code == 0)
+    RATE_LIMITED = "rate_limited"  # Rate limit hit
+    TIMEOUT = "timeout"  # exit_code == 124
+    REJECTED = "rejected"  # Claude refused task (exit 1)
+    SYSTEM_ERROR = "system_error"  # Actual crash (signal death, exit >= 128)
+
+
 @dataclass
 class ClaudeResult:
     """Result of a Claude session."""
@@ -27,8 +38,8 @@ class ClaudeResult:
     duration_seconds: int
     timed_out: bool
     rate_limited: bool
-    crashed: bool
     output: str
+    failure_category: FailureCategory = FailureCategory.NONE
     error_type: str | None = None
 
 
@@ -48,8 +59,9 @@ class ClaudeRunner:
         r"api rate limit",
     ]
 
-    # Patterns indicating Claude CLI crashed or had unhandled errors
-    CRASH_PATTERNS = [
+    # Diagnostic patterns for logging/debugging - NOT used for crash decisions
+    # Exit code is the primary determinant of crash status
+    DIAGNOSTIC_PATTERNS = [
         r"No messages returned",
         r"unhandled.*promise.*rejection",
         r"async function without a catch block",
@@ -66,25 +78,6 @@ class ClaudeRunner:
         r"core dumped",
     ]
 
-    # Patterns for valid short outputs that are NOT crashes
-    # These are legitimate error messages from Claude that happen to be short
-    VALID_SHORT_OUTPUT_PATTERNS = [
-        r"no changes",
-        r"nothing to commit",
-        r"up to date",
-        r"already exists",
-        r"permission denied",
-        r"file not found",
-        r"command not found",
-        r"successfully",
-        r"completed",
-        r"done",
-        r"skipping",
-        r"no.*tasks",
-    ]
-
-    # Default minimum output length to consider non-crash for unknown exit codes
-    DEFAULT_MIN_OUTPUT_LENGTH = 50
     # Default grace period before SIGKILL
     DEFAULT_KILL_TIMEOUT = 10
 
@@ -93,22 +86,17 @@ class ClaudeRunner:
         project_root: str | Path,
         timeout: int = 1800,  # 30 minutes default
         kill_timeout: int | None = None,  # Grace period before SIGKILL (from config)
-        min_output_length: int | None = None,  # Override min output length (from config)
         conversation_log_file: str | Path | None = None,  # Debug conversation logging
         conversation_logger: ConversationLogger | None = None,  # Injected logger (for testing)
     ) -> None:
         self.project_root = Path(project_root)
         self.timeout = timeout
         self.kill_timeout = kill_timeout if kill_timeout is not None else self.DEFAULT_KILL_TIMEOUT
-        self.min_output_length = min_output_length if min_output_length is not None else self.DEFAULT_MIN_OUTPUT_LENGTH
         self._rate_limit_patterns = [
             re.compile(p, re.IGNORECASE) for p in self.RATE_LIMIT_PATTERNS
         ]
-        self._crash_patterns = [
-            re.compile(p, re.IGNORECASE) for p in self.CRASH_PATTERNS
-        ]
-        self._valid_short_patterns = [
-            re.compile(p, re.IGNORECASE) for p in self.VALID_SHORT_OUTPUT_PATTERNS
+        self._diagnostic_patterns = [
+            re.compile(p, re.IGNORECASE) for p in self.DIAGNOSTIC_PATTERNS
         ]
 
         # Initialize conversation logger: use injected logger, create from file path, or None
@@ -131,82 +119,61 @@ class ClaudeRunner:
                 return True
         return False
 
-    def _check_crash(self, output: str) -> tuple[bool, str | None]:
-        """Check if output indicates Claude CLI crashed.
+    def _check_diagnostic(self, output: str) -> str | None:
+        """Check output for diagnostic patterns (for logging only).
+
+        This is NOT used for crash determination - exit code is authoritative.
+        Returns the matched pattern for logging/debugging purposes.
 
         Returns:
-            Tuple of (crashed, error_type)
+            The matched diagnostic pattern or None.
         """
-        for pattern in self._crash_patterns:
+        for pattern in self._diagnostic_patterns:
             match = pattern.search(output)
             if match:
-                return True, match.group(0)
-        return False, None
+                return match.group(0)
+        return None
 
-    def _is_valid_short_output(self, output: str) -> bool:
-        """Check if short output matches known valid patterns.
-
-        Some legitimate Claude responses are short but not crashes.
-
-        Args:
-            output: The output to check.
-
-        Returns:
-            True if the output matches a known valid short pattern.
-        """
-        for pattern in self._valid_short_patterns:
-            if pattern.search(output):
-                return True
-        return False
-
-    def _should_mark_as_crash(
+    def _categorize_failure(
         self,
         exit_code: int,
-        output: str,
         rate_limited: bool,
-        explicit_crash: bool,
-    ) -> tuple[bool, str | None]:
-        """Determine if the result should be marked as a crash.
+        timed_out: bool,
+    ) -> tuple[FailureCategory, str | None]:
+        """Categorize failure based primarily on exit code.
 
-        Uses multiple heuristics to avoid false positives:
-        1. If explicit crash pattern found, mark as crash
-        2. If rate limited, don't mark as crash
-        3. If exit code is 0, don't mark as crash
-        4. If output is very short AND doesn't match valid patterns, mark as crash
+        Exit code is the authoritative source for crash determination:
+        - Exit code 0 = SUCCESS (never a crash)
+        - Exit code >= 128 = SYSTEM_ERROR (killed by signal)
+        - Exit code 124 = TIMEOUT
+        - Rate limited = RATE_LIMITED
+        - Exit code 1 = REJECTED (normal failure, not crash)
 
         Args:
             exit_code: Process exit code.
-            output: Full output text.
             rate_limited: Whether rate limiting was detected.
-            explicit_crash: Whether explicit crash pattern was found.
+            timed_out: Whether the process timed out.
 
         Returns:
-            Tuple of (is_crash, error_type)
+            Tuple of (FailureCategory, error_type for logging)
         """
-        if explicit_crash:
-            return True, "crash_pattern_detected"
+        if exit_code == 0:
+            return FailureCategory.NONE, None
 
-        if rate_limited or exit_code == 0:
-            return False, None
+        if timed_out or exit_code == 124:
+            return FailureCategory.TIMEOUT, "timeout"
 
-        stripped = output.strip()
+        if rate_limited:
+            return FailureCategory.RATE_LIMITED, "rate_limited"
 
-        # Very short output with non-zero exit often indicates crash
-        if len(stripped) < self.min_output_length:
-            # But check if it matches known valid short patterns
-            if self._is_valid_short_output(stripped):
-                logger.debug(f"Short output matches valid pattern, not marking as crash")
-                return False, None
+        # Exit code >= 128 means killed by signal (128 + signal_number)
+        if exit_code >= 128:
+            signal_num = exit_code - 128
+            return FailureCategory.SYSTEM_ERROR, f"signal_{signal_num}"
 
-            # Check for common valid exit codes with short output
-            # Exit code 1 with "Aborted" or similar is not a crash
-            if exit_code == 1 and any(word in stripped.lower() for word in ["abort", "cancel", "skip"]):
-                return False, None
+        # Exit code 1-127: Normal failure (Claude refused, validation failed, etc.)
+        return FailureCategory.REJECTED, f"exit_{exit_code}"
 
-            logger.debug(f"Short output ({len(stripped)} chars) with exit code {exit_code}, marking as crash")
-            return True, f"short_output_exit_{exit_code}"
-
-        return False, None
 
     def _force_kill_process(
         self,
@@ -315,10 +282,6 @@ class ClaudeRunner:
 
         process_manager = get_process_manager()
 
-        # Event to signal crash detected in reader thread
-        crash_detected = threading.Event()
-        crash_error_type: list[str] = []  # Use list to allow mutation from thread
-
         try:
             # Start Claude in its own process group for clean termination
             cmd = self._build_claude_command(model)
@@ -341,7 +304,8 @@ class ClaudeRunner:
             if self.on_subprocess_start and process.pid:
                 self.on_subprocess_start(process.pid, " ".join(cmd))
 
-            # Stream output while capturing (with exception handling and inline crash detection)
+            # Stream output while capturing
+            # Note: Crash detection is now done via exit code, not pattern matching
             def stream_reader() -> None:
                 nonlocal reader_exception
                 try:
@@ -354,14 +318,6 @@ class ClaudeRunner:
                         output_lines.append(line)
                         if on_output:
                             on_output(line.rstrip())
-
-                        # Inline crash detection - signal main thread immediately
-                        # This prevents waiting for full timeout when Claude crashes but doesn't exit
-                        crashed, error_type = self._check_crash(line)
-                        if crashed and not crash_detected.is_set():
-                            crash_error_type.append(error_type or "crash_detected")
-                            crash_detected.set()
-                            logger.debug(f"Crash pattern detected in output: {error_type}")
                 except BrokenPipeError:
                     # Expected when process dies - not an error
                     logger.debug("Reader thread: broken pipe (process died)")
@@ -384,25 +340,13 @@ class ClaudeRunner:
                 # Claude died before reading input
                 pass
 
-            # Wait for completion with timeout, but also check for crash detection
-            # Use shorter poll intervals to detect crashes faster
+            # Wait for completion with timeout
             poll_interval = 1.0  # Check every second
             elapsed_wait = 0.0
             timed_out = False
             exit_code = None
 
             while exit_code is None and elapsed_wait < self.timeout:
-                # Check if crash was detected - give brief grace period for clean exit
-                if crash_detected.is_set():
-                    logger.debug("Crash detected, giving 5s grace period for clean exit")
-                    try:
-                        exit_code = process.wait(timeout=5)
-                        break
-                    except subprocess.TimeoutExpired:
-                        logger.debug("Process didn't exit after crash, force killing")
-                        exit_code = 1
-                        break
-
                 # Poll process status
                 exit_code = process.poll()
                 if exit_code is not None:
@@ -463,7 +407,7 @@ class ClaudeRunner:
                 duration_seconds=int(time.time() - start_time),
                 timed_out=False,
                 rate_limited=False,
-                crashed=True,
+                failure_category=FailureCategory.SYSTEM_ERROR,
                 output=f"Error running Claude: {e}",
                 error_type=str(type(e).__name__),
             )
@@ -476,18 +420,21 @@ class ClaudeRunner:
             Path(output_file).write_text(full_output)
 
         rate_limited = self._check_rate_limit(full_output)
-        explicit_crash, explicit_error = self._check_crash(full_output)
 
-        # Improved crash detection with multiple heuristics
-        crashed, error_type = self._should_mark_as_crash(
+        # Exit-code-first failure categorization
+        failure_category, error_type = self._categorize_failure(
             exit_code=exit_code,
-            output=full_output,
             rate_limited=rate_limited,
-            explicit_crash=explicit_crash,
+            timed_out=timed_out,
         )
-        # Preserve explicit error type if available
-        if explicit_crash and explicit_error:
-            error_type = explicit_error
+
+        # Check for diagnostic patterns (logging only, not for decision-making)
+        diagnostic_match = self._check_diagnostic(full_output)
+        if diagnostic_match:
+            logger.debug(f"Diagnostic pattern found in output: {diagnostic_match}")
+            # Include diagnostic info in error_type if we have a failure
+            if failure_category != FailureCategory.NONE and error_type:
+                error_type = f"{error_type}:{diagnostic_match}"
 
         # Log conversation if debug mode is enabled
         if self.conversation_logger:
@@ -505,7 +452,173 @@ class ClaudeRunner:
             duration_seconds=duration,
             timed_out=timed_out,
             rate_limited=rate_limited,
-            crashed=crashed,
+            failure_category=failure_category,
+            output=full_output,
+            error_type=error_type,
+        )
+
+    async def _execute_session_async(
+        self,
+        prompt_content: str,
+        source_name: str,
+        output_file: str | Path | None = None,
+        on_output: Callable[[str], None] | None = None,
+        model: str | None = None,
+    ) -> ClaudeResult:
+        """Execute a Claude session asynchronously (primary async implementation).
+
+        This is the async core execution method using asyncio.create_subprocess_exec().
+        No background threads are used - output is read via async iteration.
+
+        Args:
+            prompt_content: The fully prepared prompt content to send to Claude.
+            source_name: Name for logging purposes (e.g., "PROMPT_init.xml.j2").
+            output_file: Optional file to capture output for rate limit detection.
+            on_output: Optional callback for streaming output lines.
+            model: Model to use ("opus" or "sonnet"). If None, uses CLI default.
+
+        Returns:
+            ClaudeResult with exit code, duration, and status flags.
+        """
+        start_time = time.time()
+        output_lines: list[str] = []
+
+        process_manager = get_process_manager()
+
+        try:
+            cmd = self._build_claude_command(model)
+            logger.debug(f"Running Claude async with command: {' '.join(cmd)}")
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=self.project_root,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=True,  # Create new process group
+            )
+
+            # Register process for cleanup tracking
+            if process.pid:
+                process_manager.register_pid(process.pid)
+
+            # Notify subprocess start
+            if self.on_subprocess_start and process.pid:
+                self.on_subprocess_start(process.pid, " ".join(cmd))
+
+            # Read output asynchronously (no thread needed)
+            async def read_output() -> None:
+                assert process.stdout is not None
+                try:
+                    async for line in process.stdout:
+                        decoded = line.decode("utf-8", errors="replace")
+                        output_lines.append(decoded)
+                        if on_output:
+                            on_output(decoded.rstrip())
+                except asyncio.CancelledError:
+                    logger.debug("Async reader cancelled")
+                    raise
+                except Exception as e:
+                    logger.warning(f"Async reader exception: {type(e).__name__}: {e}")
+
+            # Start reading task
+            read_task = asyncio.create_task(read_output())
+
+            # Send prompt (handle broken pipe if Claude dies immediately)
+            assert process.stdin is not None
+            try:
+                process.stdin.write(prompt_content.encode())
+                await process.stdin.drain()
+                process.stdin.close()
+                await process.stdin.wait_closed()
+            except (BrokenPipeError, ConnectionResetError):
+                pass  # Claude died before reading input
+
+            # Wait with timeout
+            timed_out = False
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(read_task, process.wait(), return_exceptions=True),
+                    timeout=self.timeout,
+                )
+                exit_code = process.returncode or 0
+            except asyncio.TimeoutError:
+                timed_out = True
+                # Cancel the read task
+                read_task.cancel()
+                try:
+                    await read_task
+                except asyncio.CancelledError:
+                    pass
+
+                # Kill process group
+                await self._force_kill_process_async(process)
+                exit_code = 124
+
+            # Unregister process now that it's done
+            if process.pid:
+                process_manager.unregister_pid(process.pid)
+
+            # Notify subprocess end
+            if self.on_subprocess_end:
+                self.on_subprocess_end()
+
+        except Exception as e:
+            # Notify subprocess end on exception
+            if self.on_subprocess_end:
+                self.on_subprocess_end()
+            # Ensure process is unregistered on exception
+            if 'process' in locals() and process.pid:
+                process_manager.unregister_pid(process.pid)
+            return ClaudeResult(
+                exit_code=1,
+                duration_seconds=int(time.time() - start_time),
+                timed_out=False,
+                rate_limited=False,
+                failure_category=FailureCategory.SYSTEM_ERROR,
+                output=f"Error running Claude: {e}",
+                error_type=str(type(e).__name__),
+            )
+
+        duration = int(time.time() - start_time)
+        full_output = "".join(output_lines)
+
+        # Write to output file if specified
+        if output_file:
+            Path(output_file).write_text(full_output)
+
+        rate_limited = self._check_rate_limit(full_output)
+
+        # Exit-code-first failure categorization
+        failure_category, error_type = self._categorize_failure(
+            exit_code=exit_code,
+            rate_limited=rate_limited,
+            timed_out=timed_out,
+        )
+
+        # Check for diagnostic patterns (logging only)
+        diagnostic_match = self._check_diagnostic(full_output)
+        if diagnostic_match:
+            logger.debug(f"Diagnostic pattern found in output: {diagnostic_match}")
+            if failure_category != FailureCategory.NONE and error_type:
+                error_type = f"{error_type}:{diagnostic_match}"
+
+        # Log conversation if debug mode is enabled
+        if self.conversation_logger:
+            self.conversation_logger.log_interaction(
+                source=source_name,
+                input_text=prompt_content,
+                output_text=full_output,
+                exit_code=exit_code,
+                model=model,
+                duration_seconds=duration,
+            )
+
+        return ClaudeResult(
+            exit_code=exit_code,
+            duration_seconds=duration,
+            timed_out=timed_out,
+            rate_limited=rate_limited,
+            failure_category=failure_category,
             output=full_output,
             error_type=error_type,
         )
@@ -559,7 +672,7 @@ class ClaudeRunner:
                 duration_seconds=0,
                 timed_out=False,
                 rate_limited=False,
-                crashed=False,
+                failure_category=FailureCategory.REJECTED,
                 output=f"Prompt file not found: {prompt_path}",
             )
 
@@ -574,7 +687,7 @@ class ClaudeRunner:
             model=model,
         )
 
-    def run_with_content(
+    async def run_with_content_async(
         self,
         prompt_content: str,
         source_name: str = "prompt",
@@ -583,10 +696,10 @@ class ClaudeRunner:
         model: str | None = None,
         context: str | None = None,
     ) -> ClaudeResult:
-        """Run Claude with prompt content directly (not from a file).
+        """Run Claude with prompt content directly (async version).
 
-        This method is useful when prompts are loaded from package resources
-        via importlib.resources rather than from filesystem paths.
+        This is the primary async method for running Claude with content.
+        Uses asyncio subprocess handling - no background threads.
 
         Args:
             prompt_content: The prompt content to send to Claude.
@@ -601,12 +714,69 @@ class ClaudeRunner:
         """
         prompt_content = self._prepare_prompt_content(prompt_content, context)
 
-        return self._execute_session(
+        return await self._execute_session_async(
             prompt_content=prompt_content,
             source_name=source_name,
             output_file=output_file,
             on_output=on_output,
             model=model,
+        )
+
+    def run_with_content(
+        self,
+        prompt_content: str,
+        source_name: str = "prompt",
+        output_file: str | Path | None = None,
+        on_output: Callable[[str], None] | None = None,
+        model: str | None = None,
+        context: str | None = None,
+    ) -> ClaudeResult:
+        """Run Claude with prompt content directly (sync wrapper).
+
+        This method is useful when prompts are loaded from package resources
+        via importlib.resources rather than from filesystem paths.
+
+        For async callers, prefer run_with_content_async() to avoid event loop issues.
+
+        Args:
+            prompt_content: The prompt content to send to Claude.
+            source_name: Name for logging purposes (e.g., "PROMPT_init.xml.j2").
+            output_file: Optional file to capture output for rate limit detection.
+            on_output: Optional callback for streaming output lines.
+            model: Model to use ("opus" or "sonnet"). If None, uses CLI default.
+            context: Optional context to prepend to the prompt content.
+
+        Returns:
+            ClaudeResult with exit code, duration, and status flags.
+        """
+        # Check if we're in an existing event loop
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None:
+            # We're already in an async context - can't use asyncio.run()
+            # Fall back to the threading-based sync implementation
+            prompt_content = self._prepare_prompt_content(prompt_content, context)
+            return self._execute_session(
+                prompt_content=prompt_content,
+                source_name=source_name,
+                output_file=output_file,
+                on_output=on_output,
+                model=model,
+            )
+
+        # Not in an event loop - use asyncio.run() with async implementation
+        return asyncio.run(
+            self.run_with_content_async(
+                prompt_content=prompt_content,
+                source_name=source_name,
+                output_file=output_file,
+                on_output=on_output,
+                model=model,
+                context=context,
+            )
         )
 
     async def run_prompt_async(
@@ -616,6 +786,8 @@ class ClaudeRunner:
         model: str | None = None,
     ) -> ClaudeResult:
         """Run Claude with a prompt file asynchronously.
+
+        Uses the async execution method - no background threads.
 
         Args:
             prompt_file: Path to the prompt file to pipe to Claude.
@@ -632,135 +804,17 @@ class ClaudeRunner:
                 duration_seconds=0,
                 timed_out=False,
                 rate_limited=False,
-                crashed=False,
+                failure_category=FailureCategory.REJECTED,
                 output=f"Prompt file not found: {prompt_path}",
             )
 
         prompt_content = prompt_path.read_text()
 
-        start_time = time.time()
-        output_lines: list[str] = []
-
-        process_manager = get_process_manager()
-
-        try:
-            cmd = self._build_claude_command(model)
-            logger.debug(f"Running Claude async with command: {' '.join(cmd)}")
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                cwd=self.project_root,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                start_new_session=True,  # Create new process group
-            )
-
-            # Register process for cleanup tracking
-            if process.pid:
-                process_manager.register_pid(process.pid)
-
-            # Send prompt and read output concurrently
-            async def read_output():
-                assert process.stdout is not None
-                try:
-                    async for line in process.stdout:
-                        decoded = line.decode("utf-8", errors="replace")
-                        output_lines.append(decoded)
-                        if on_output:
-                            on_output(decoded.rstrip())
-                except asyncio.CancelledError:
-                    logger.debug("Async reader cancelled")
-                    raise
-                except Exception as e:
-                    logger.warning(f"Async reader exception: {type(e).__name__}: {e}")
-
-            # Start reading
-            read_task = asyncio.create_task(read_output())
-
-            # Send prompt (handle broken pipe if Claude dies immediately)
-            assert process.stdin is not None
-            try:
-                process.stdin.write(prompt_content.encode())
-                await process.stdin.drain()
-                process.stdin.close()
-                await process.stdin.wait_closed()
-            except (BrokenPipeError, ConnectionResetError):
-                pass  # Claude died before reading input
-
-            # Wait with timeout
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(read_task, process.wait(), return_exceptions=True),
-                    timeout=self.timeout,
-                )
-                exit_code = process.returncode or 0
-                timed_out = False
-            except asyncio.TimeoutError:
-                # Cancel the read task
-                read_task.cancel()
-                try:
-                    await read_task
-                except asyncio.CancelledError:
-                    pass
-
-                # Kill process group
-                await self._force_kill_process_async(process)
-                exit_code = 124
-                timed_out = True
-
-            # Unregister process now that it's done
-            if process.pid:
-                process_manager.unregister_pid(process.pid)
-
-        except Exception as e:
-            # Ensure process is unregistered on exception
-            if 'process' in locals() and process.pid:
-                process_manager.unregister_pid(process.pid)
-            return ClaudeResult(
-                exit_code=1,
-                duration_seconds=int(time.time() - start_time),
-                timed_out=False,
-                rate_limited=False,
-                crashed=True,
-                output=f"Error running Claude: {e}",
-                error_type=str(type(e).__name__),
-            )
-
-        duration = int(time.time() - start_time)
-        full_output = "".join(output_lines)
-        rate_limited = self._check_rate_limit(full_output)
-        explicit_crash, explicit_error = self._check_crash(full_output)
-
-        # Improved crash detection with multiple heuristics
-        crashed, error_type = self._should_mark_as_crash(
-            exit_code=exit_code,
-            output=full_output,
-            rate_limited=rate_limited,
-            explicit_crash=explicit_crash,
-        )
-        # Preserve explicit error type if available
-        if explicit_crash and explicit_error:
-            error_type = explicit_error
-
-        # Log conversation if debug mode is enabled
-        if self.conversation_logger:
-            self.conversation_logger.log_interaction(
-                source=str(prompt_path.name),
-                input_text=prompt_content,
-                output_text=full_output,
-                exit_code=exit_code,
-                model=model,
-                duration_seconds=duration,
-            )
-
-        return ClaudeResult(
-            exit_code=exit_code,
-            duration_seconds=duration,
-            timed_out=timed_out,
-            rate_limited=rate_limited,
-            crashed=crashed,
-            output=full_output,
-            error_type=error_type,
+        return await self._execute_session_async(
+            prompt_content=prompt_content,
+            source_name=str(prompt_path.name),
+            on_output=on_output,
+            model=model,
         )
 
     async def stream_prompt(
@@ -842,11 +896,10 @@ class ClaudeRunner:
                 decoded = line.decode("utf-8", errors="replace").rstrip()
                 yield decoded
 
-                # Check for crash patterns in output
-                crashed, error_type = self._check_crash(decoded)
-                if crashed:
-                    yield f"Error: Claude crash detected: {error_type}"
-                    break
+                # Check for diagnostic patterns (for logging info only)
+                diagnostic_match = self._check_diagnostic(decoded)
+                if diagnostic_match:
+                    logger.debug(f"Diagnostic pattern in stream: {diagnostic_match}")
 
         finally:
             # Clean up process

--- a/claudesprint/core/claude_runner.py
+++ b/claudesprint/core/claude_runner.py
@@ -736,7 +736,10 @@ class ClaudeRunner:
         This method is useful when prompts are loaded from package resources
         via importlib.resources rather than from filesystem paths.
 
-        For async callers, prefer run_with_content_async() to avoid event loop issues.
+        Note: When called within an existing async event loop, this falls back
+        to threading-based execution (_execute_session) since asyncio.run()
+        cannot be nested. For async contexts, use run_with_content_async()
+        directly to use the pure async implementation.
 
         Args:
             prompt_content: The prompt content to send to Claude.

--- a/claudesprint/core/sprint_engine.py
+++ b/claudesprint/core/sprint_engine.py
@@ -15,7 +15,7 @@ from typing import Callable
 
 import re
 
-from claudesprint.core.claude_runner import ClaudeRunner, ClaudeResult
+from claudesprint.core.claude_runner import ClaudeRunner, ClaudeResult, FailureCategory as ClaudeFailureCategory
 from claudesprint.core.issue_engine import IssueEngine, IssueResult, IssueExitReason
 from claudesprint.core.issue_state_machine import IssueStateMachine, SprintAction
 from claudesprint.core.iteration_tracker import IterationTracker, FailureCategory
@@ -469,8 +469,8 @@ class SprintEngine:
                 error="Rate limited during issue selection",
             )
 
-        # Handle crash
-        if result.crashed:
+        # Handle system error (crash)
+        if result.failure_category == ClaudeFailureCategory.SYSTEM_ERROR:
             return IssueSelectionResult(
                 success=False,
                 issue_id=None,

--- a/claudesprint/core/step_executors.py
+++ b/claudesprint/core/step_executors.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from pathlib import Path
 
-from claudesprint.core.claude_runner import ClaudeResult, ClaudeRunner
+from claudesprint.core.claude_runner import ClaudeResult, ClaudeRunner, FailureCategory
 from claudesprint.core.step_types import ParseResult, StepResult
 from claudesprint.models.current_issue import CurrentIssue, IssueStep
 from claudesprint.models.sprint import IssueStatus
@@ -244,8 +244,8 @@ class LlmStepExecutor(StepExecutor):
                 rate_limited=True,
             )
 
-        # Check for crash
-        if result.crashed:
+        # Check for system error (crash)
+        if result.failure_category == FailureCategory.SYSTEM_ERROR:
             return StepResult(
                 success=False,
                 next_step=None,

--- a/claudesprint/services/heartbeat_service.py
+++ b/claudesprint/services/heartbeat_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
 import time
@@ -165,8 +166,188 @@ class HeartbeatService:
             self._hung_notified = False
 
 
-# Global instance
+class AsyncHeartbeatService:
+    """Async heartbeat service using asyncio instead of threads.
+
+    This service monitors workflow activity and detects hung processes
+    using an asyncio task instead of a background thread.
+    """
+
+    # Default check interval (can be overridden via config)
+    DEFAULT_CHECK_INTERVAL = 10.0
+
+    def __init__(
+        self,
+        timeout_seconds: int = 600,
+        enabled: bool = True,
+        on_hung: Callable[[str, int], None] | None = None,
+        check_interval: float | None = None,
+        event_bus: "WorkflowEventBus | None" = None,
+    ) -> None:
+        """Initialize the async heartbeat service.
+
+        Args:
+            timeout_seconds: Seconds of inactivity before triggering hung detection.
+            enabled: Whether heartbeat monitoring is enabled.
+            on_hung: Callback when hung process detected (step_name, seconds_inactive).
+            check_interval: How often to check for inactivity (from config).
+            event_bus: Optional event bus for emitting PROCESS_HUNG events.
+        """
+        self._timeout_seconds = timeout_seconds
+        self._enabled = enabled
+        self._on_hung = on_hung
+        self._check_interval = check_interval if check_interval is not None else self.DEFAULT_CHECK_INTERVAL
+        self._event_bus = event_bus
+
+        self._last_pulse: float = 0
+        self._current_step: str = ""
+        self._running = False
+        self._monitor_task: asyncio.Task | None = None
+        self._stop_event = asyncio.Event()
+
+        # Track if we've already notified for current hung state
+        self._hung_notified = False
+
+        # Use threading.Lock for pulse() since it's called from sync code paths
+        # (e.g., output handlers). This provides cross-thread safety.
+        self._lock = threading.Lock()
+
+    def pulse(self, step: "WorkflowStep | str") -> None:
+        """Record activity pulse, resetting the inactivity timer.
+
+        This method is synchronous to allow calling from sync code paths
+        (e.g., output handlers in ClaudeRunner callbacks).
+
+        Args:
+            step: The current workflow step.
+        """
+        with self._lock:
+            self._last_pulse = time.time()
+            step_name = step.value if hasattr(step, 'value') else str(step)
+            if step_name != self._current_step:
+                self._current_step = step_name
+                self._hung_notified = False  # Reset notification flag on step change
+
+    async def start(self) -> None:
+        """Start the async heartbeat monitoring task."""
+        if not self._enabled:
+            return
+
+        with self._lock:
+            if self._running:
+                return
+            self._running = True
+            self._last_pulse = time.time()
+
+        self._stop_event.clear()
+        self._monitor_task = asyncio.create_task(self._monitor_loop())
+
+    async def stop(self) -> None:
+        """Stop the async heartbeat monitoring task."""
+        with self._lock:
+            if not self._running:
+                return
+            self._running = False
+
+        self._stop_event.set()
+
+        if self._monitor_task:
+            try:
+                # Give the task a moment to notice the stop event
+                await asyncio.wait_for(self._monitor_task, timeout=2.0)
+            except asyncio.TimeoutError:
+                logger.warning("Heartbeat monitor task did not stop in time, cancelling")
+                self._monitor_task.cancel()
+                try:
+                    await self._monitor_task
+                except asyncio.CancelledError:
+                    pass
+            self._monitor_task = None
+
+    async def _monitor_loop(self) -> None:
+        """Async monitor loop that checks for inactivity."""
+        while True:
+            try:
+                # Wait for either the stop event or timeout
+                await asyncio.wait_for(
+                    self._stop_event.wait(),
+                    timeout=self._check_interval
+                )
+                # Stop event was set
+                break
+            except asyncio.TimeoutError:
+                # Timeout expired - check for inactivity
+                pass
+
+            # Check inactivity under lock
+            with self._lock:
+                if not self._running:
+                    break
+
+                if self._last_pulse == 0:
+                    continue
+
+                elapsed = time.time() - self._last_pulse
+                should_notify = elapsed >= self._timeout_seconds and not self._hung_notified
+                if should_notify:
+                    step = self._current_step
+                    self._hung_notified = True
+
+            # Call callback and emit event outside of lock (only once per hung state)
+            if should_notify:
+                # Emit PROCESS_HUNG event
+                if self._event_bus:
+                    try:
+                        self._event_bus.emit(WorkflowEvent.PROCESS_HUNG, {
+                            "step_name": step,
+                            "seconds_inactive": int(elapsed),
+                            "timestamp": datetime.now(UTC).isoformat(),
+                        })
+                    except Exception as e:
+                        logger.warning(f"Failed to emit PROCESS_HUNG event: {e}")
+
+                # Call callback
+                if self._on_hung:
+                    try:
+                        self._on_hung(step, int(elapsed))
+                    except Exception as e:
+                        logger.warning(f"Heartbeat callback failed: {e}")
+
+    @property
+    def is_running(self) -> bool:
+        """Check if heartbeat monitoring is running."""
+        with self._lock:
+            return self._running
+
+    @property
+    def seconds_since_pulse(self) -> int:
+        """Get seconds since last pulse."""
+        with self._lock:
+            if self._last_pulse == 0:
+                return 0
+            return int(time.time() - self._last_pulse)
+
+    async def reset(self) -> None:
+        """Reset the service state (for testing)."""
+        await self.stop()
+        with self._lock:
+            self._last_pulse = 0
+            self._current_step = ""
+            self._hung_notified = False
+
+    async def __aenter__(self) -> "AsyncHeartbeatService":
+        """Async context manager entry."""
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Async context manager exit."""
+        await self.stop()
+
+
+# Global instances
 _heartbeat_service: HeartbeatService | None = None
+_async_heartbeat_service: AsyncHeartbeatService | None = None
 
 
 def get_heartbeat_service(
@@ -174,9 +355,9 @@ def get_heartbeat_service(
     enabled: bool = True,
     on_hung: Callable[[str, int], None] | None = None,
     check_interval: float | None = None,
-    event_bus: WorkflowEventBus | None = None,
+    event_bus: "WorkflowEventBus | None" = None,
 ) -> HeartbeatService:
-    """Get or create the global heartbeat service instance.
+    """Get or create the global heartbeat service instance (thread-based).
 
     Args:
         timeout_seconds: Seconds of inactivity before triggering hung detection.
@@ -200,9 +381,48 @@ def get_heartbeat_service(
     return _heartbeat_service
 
 
+def get_async_heartbeat_service(
+    timeout_seconds: int = 600,
+    enabled: bool = True,
+    on_hung: Callable[[str, int], None] | None = None,
+    check_interval: float | None = None,
+    event_bus: "WorkflowEventBus | None" = None,
+) -> AsyncHeartbeatService:
+    """Get or create the global async heartbeat service instance.
+
+    Args:
+        timeout_seconds: Seconds of inactivity before triggering hung detection.
+        enabled: Whether heartbeat monitoring is enabled.
+        on_hung: Callback when hung process detected.
+        check_interval: How often to check for inactivity (from config).
+        event_bus: Optional event bus for emitting PROCESS_HUNG events.
+
+    Returns:
+        The global AsyncHeartbeatService instance.
+    """
+    global _async_heartbeat_service
+    if _async_heartbeat_service is None:
+        _async_heartbeat_service = AsyncHeartbeatService(
+            timeout_seconds=timeout_seconds,
+            enabled=enabled,
+            on_hung=on_hung,
+            check_interval=check_interval,
+            event_bus=event_bus,
+        )
+    return _async_heartbeat_service
+
+
 def reset_heartbeat_service() -> None:
     """Reset the global heartbeat service (for testing)."""
     global _heartbeat_service
     if _heartbeat_service:
         _heartbeat_service.reset()
     _heartbeat_service = None
+
+
+async def reset_async_heartbeat_service() -> None:
+    """Reset the global async heartbeat service (for testing)."""
+    global _async_heartbeat_service
+    if _async_heartbeat_service:
+        await _async_heartbeat_service.reset()
+    _async_heartbeat_service = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,13 +163,14 @@ def mock_claude_runner():
 
     Example:
         def test_something(mock_claude_runner):
+            from claudesprint.core.claude_runner import ClaudeResult, FailureCategory
             mock_claude_runner.run_prompt.return_value = ClaudeResult(
                 exit_code=0,
                 duration_seconds=10,
                 timed_out=False,
                 rate_limited=False,
-                crashed=False,
                 output="Test output",
+                failure_category=FailureCategory.NONE,
             )
     """
     return Mock(spec=ClaudeRunner)

--- a/tests/test_step_executors.py
+++ b/tests/test_step_executors.py
@@ -4,7 +4,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from claudesprint.core.claude_runner import ClaudeResult
+from claudesprint.core.claude_runner import ClaudeResult, FailureCategory
 from claudesprint.core.issue_engine import ParseResult, StepResult
 from claudesprint.core.step_executors import (
     CompletionStepExecutor,
@@ -57,7 +57,7 @@ def mock_claude_runner() -> MagicMock:
         duration_seconds=10,
         timed_out=False,
         rate_limited=False,
-        crashed=False,
+        failure_category=FailureCategory.NONE,
         output="Successful execution output\n<routing_signal>pass</routing_signal>",
         error_type=None,
     )
@@ -210,7 +210,7 @@ class TestLlmStepExecutor:
             duration_seconds=5,
             timed_out=False,
             rate_limited=True,
-            crashed=False,
+            failure_category=FailureCategory.RATE_LIMITED,
             output="You've hit your limit. Please try again later.",
             error_type=None,
         )
@@ -230,16 +230,16 @@ class TestLlmStepExecutor:
         sample_current_issue: CurrentIssue,
         mock_claude_runner: MagicMock,
     ) -> None:
-        """Test handling of crash (result.crashed = True)."""
-        # Configure mock to return crashed result
+        """Test handling of crash (result.crashed = True via SYSTEM_ERROR)."""
+        # Configure mock to return crashed result (SYSTEM_ERROR category)
         mock_claude_runner.run_with_content.return_value = ClaudeResult(
-            exit_code=1,
+            exit_code=137,  # SIGKILL (128 + 9)
             duration_seconds=2,
             timed_out=False,
             rate_limited=False,
-            crashed=True,
+            failure_category=FailureCategory.SYSTEM_ERROR,
             output="No messages returned",
-            error_type="crash_pattern_detected",
+            error_type="signal_9",
         )
 
         # Execute the step
@@ -250,7 +250,7 @@ class TestLlmStepExecutor:
         assert result.crashed is True
         assert result.rate_limited is False
         assert result.next_step is None
-        assert result.error == "crash_pattern_detected"
+        assert result.error == "signal_9"
 
     def test_prompt_not_found_error(
         self,
@@ -322,7 +322,7 @@ class TestLlmStepExecutor:
             duration_seconds=10,
             timed_out=False,
             rate_limited=False,
-            crashed=False,
+            failure_category=FailureCategory.NONE,
             output="Tests completed but no status tag provided",
             error_type=None,
         )
@@ -502,15 +502,15 @@ class TestLlmStepExecutor:
             output_patterns={},
         )
 
-        # Configure mock to return non-zero exit code
+        # Configure mock to return non-zero exit code (REJECTED category)
         mock_claude_runner.run_with_content.return_value = ClaudeResult(
             exit_code=1,
             duration_seconds=10,
             timed_out=False,
             rate_limited=False,
-            crashed=False,
+            failure_category=FailureCategory.REJECTED,
             output="Command failed with error",
-            error_type=None,
+            error_type="exit_1",
         )
 
         current_issue = CurrentIssue(
@@ -727,7 +727,7 @@ class TestEdgeCases:
             duration_seconds=5,
             timed_out=False,
             rate_limited=False,
-            crashed=False,
+            failure_category=FailureCategory.NONE,
             output="",
             error_type=None,
         )


### PR DESCRIPTION
## Summary
- Refactors ClaudeRunner from threading-based to asyncio-based architecture
- Implements exit-code-first crash detection with `FailureCategory` enum
- Adds `AsyncHeartbeatService` class using asyncio.Task instead of threading.Thread
- Removes backwards compatibility code (`crashed` property) in favor of direct `failure_category` checks

## Changes

### Phase 1: Exit-Code-First Crash Detection
- Added `FailureCategory` enum: `NONE`, `RATE_LIMITED`, `TIMEOUT`, `REJECTED`, `SYSTEM_ERROR`
- Added `_categorize_failure()` method that determines failure based on exit code
- Renamed `CRASH_PATTERNS` to `DIAGNOSTIC_PATTERNS` (for logging only)

### Phase 2: Async ClaudeRunner
- Added `_execute_session_async()` as the primary async implementation
- Added `run_with_content_async()` public async method
- Updated `run_with_content()` to detect running event loops
- Simplified `run_prompt_async()` to use shared async implementation

### Phase 3: Async HeartbeatService
- Added `AsyncHeartbeatService` class using `asyncio.Task`
- Uses `asyncio.Event` for stop signaling
- Added async context manager support
- `pulse()` remains synchronous for callback compatibility

## Test plan
- [x] Run `pytest tests/test_step_executors.py -v` - all 26 tests pass
- [x] Run full test suite - 660/663 tests pass (3 unrelated failures)
- [x] Verify imports work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)