### PR TITLE
refactor: Simplify CLI for public release

### DIFF
--- a/claudesprint/cli.py
+++ b/claudesprint/cli.py
@@ -18,7 +18,9 @@ from claudesprint.commands import doctor as doctor_module
 from claudesprint.commands import hook as hook_module
 from claudesprint.commands import init as init_module
 from claudesprint.commands import initrepo as initrepo_module
+from claudesprint.commands import quickstart as quickstart_module
 from claudesprint.commands import run as run_module
+from claudesprint.commands import spec as spec_module
 from claudesprint.commands import status as status_module
 from claudesprint.commands import utils as utils_module
 
@@ -64,9 +66,11 @@ app.command("notify")(utils_module.send_notification)
 app.command("doctor")(doctor_module.doctor)
 app.command("hook")(hook_module.run_hook)
 app.command("initrepo")(initrepo_module.init_repo)
+app.command("quickstart")(quickstart_module.quickstart)
 
-# Register config sub-app
+# Register command groups
 app.add_typer(config_module.config_app, name="config")
+app.add_typer(spec_module.spec_app, name="spec")
 
 
 if __name__ == "__main__":

--- a/claudesprint/cli.py
+++ b/claudesprint/cli.py
@@ -4,6 +4,7 @@ This is a lightweight router that registers commands from the commands/ modules.
 Heavy imports are deferred to command modules for fast startup.
 """
 
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -14,21 +15,111 @@ from claudesprint.utils.process_manager import get_process_manager
 
 # Import command modules
 from claudesprint.commands import config as config_module
+from claudesprint.commands import demo as demo_module
 from claudesprint.commands import doctor as doctor_module
 from claudesprint.commands import hook as hook_module
 from claudesprint.commands import init as init_module
-from claudesprint.commands import initrepo as initrepo_module
 from claudesprint.commands import quickstart as quickstart_module
 from claudesprint.commands import run as run_module
 from claudesprint.commands import spec as spec_module
 from claudesprint.commands import status as status_module
 from claudesprint.commands import utils as utils_module
 
+# Help panel groupings for better discoverability
+PANEL_GETTING_STARTED = "Getting Started"
+PANEL_WORKFLOW = "Workflow"
+PANEL_SETUP = "Setup"
+PANEL_UTILITIES = "Utilities"
+
 app = typer.Typer(
     name="claudesprint",
     help="ClaudeSprint - Autonomous workflow orchestration for AI-driven development",
     no_args_is_help=False,
+    rich_markup_mode="rich",
 )
+
+
+def _is_first_run() -> bool:
+    """Check if this is first run (no .claudesprint/ directory)."""
+    return not (Path.cwd() / ".claudesprint").exists()
+
+
+def _check_claude_cli() -> tuple[bool, bool]:
+    """Quick check for Claude CLI availability.
+
+    Returns:
+        Tuple of (cli_installed, cli_authenticated).
+    """
+    import shutil
+
+    claude_path = shutil.which("claude")
+    if not claude_path:
+        return False, False
+
+    # Check for credentials file directly - fast and reliable
+    credentials_path = Path.home() / ".claude" / ".credentials.json"
+
+    if credentials_path.exists():
+        try:
+            content = credentials_path.read_text()
+            if len(content) > 10:  # Minimal valid JSON
+                return True, True
+        except (OSError, PermissionError):
+            pass
+
+    return True, False  # Installed but not authenticated
+
+
+def _show_welcome() -> None:
+    """Show welcome screen for first-time users."""
+    from rich.panel import Panel
+
+    # Check Claude CLI status
+    cli_installed, cli_authed = _check_claude_cli()
+
+    console.print("")
+    console.print(Panel.fit(
+        "[bold cyan]Welcome to ClaudeSprint![/bold cyan]",
+        border_style="cyan",
+    ))
+    console.print("")
+
+    if not cli_installed:
+        console.print("[bold red]⚠ Claude CLI Required[/bold red]")
+        console.print("")
+        console.print("ClaudeSprint uses Claude Code CLI to orchestrate AI agents.")
+        console.print("")
+        console.print("[bold]Install Claude CLI:[/bold]")
+        console.print("  https://docs.anthropic.com/en/docs/claude-code")
+        console.print("")
+        console.print("[bold]Then authenticate:[/bold]")
+        console.print("  [cyan]claude login[/cyan]")
+        console.print("")
+        console.print("[dim]After setup, run:[/dim] [cyan]claudesprint quickstart[/cyan]")
+        return
+
+    if not cli_authed:
+        console.print("[bold yellow]⚠ Claude CLI Not Authenticated[/bold yellow]")
+        console.print("")
+        console.print("[bold]Run:[/bold] [cyan]claude login[/cyan]")
+        console.print("")
+        console.print("[dim]After login, run:[/dim] [cyan]claudesprint quickstart[/cyan]")
+        return
+
+    # All good - show quickstart options
+    console.print("[bold green]✓ Environment ready[/bold green]")
+    console.print("")
+    console.print("[bold]Get started:[/bold]")
+    console.print("")
+    console.print("  [cyan]claudesprint quickstart[/cyan]")
+    console.print("      Interactive setup - creates spec and initializes sprint")
+    console.print("")
+    console.print("  [cyan]claudesprint demo[/cyan]")
+    console.print("      Try with a sample project - see results immediately")
+    console.print("")
+    console.print("[bold]Other commands:[/bold]")
+    console.print("  [dim]claudesprint doctor[/dim]    Check environment")
+    console.print("  [dim]claudesprint --help[/dim]    All commands")
 
 
 @app.callback(invoke_without_command=True)
@@ -48,29 +139,38 @@ def main(
         console.print(f"claudesprint version {__version__}")
         raise typer.Exit()
 
-    # If no subcommand, show status
+    # If no subcommand provided
     if ctx.invoked_subcommand is None:
-        status_module.show_status()
+        # First run? Show welcome instead of status
+        if _is_first_run():
+            _show_welcome()
+        else:
+            status_module.show_status()
 
 
-# Register commands from modules
-app.command("run")(run_module.run_workflow)
-app.command("init")(init_module.init_project)
-app.command("plan")(init_module.run_planner)
-app.command("status")(status_module.show_status)
-app.command("models")(status_module.show_models)
-app.command("sprints")(status_module.list_sprints)
-app.command("validate")(utils_module.validate_sprint)
-app.command("reset")(utils_module.reset_sprint)
-app.command("notify")(utils_module.send_notification)
-app.command("doctor")(doctor_module.doctor)
-app.command("hook")(hook_module.run_hook)
-app.command("initrepo")(initrepo_module.init_repo)
-app.command("quickstart")(quickstart_module.quickstart)
+# Register commands with help panel groupings for better discoverability
+# Getting Started - first things new users should try
+app.command("quickstart", rich_help_panel=PANEL_GETTING_STARTED)(quickstart_module.quickstart)
+app.command("demo", rich_help_panel=PANEL_GETTING_STARTED)(demo_module.demo)
+app.command("doctor", rich_help_panel=PANEL_GETTING_STARTED)(doctor_module.doctor)
+
+# Workflow - daily usage commands
+app.command("run", rich_help_panel=PANEL_WORKFLOW)(run_module.run_workflow)
+app.command("status", rich_help_panel=PANEL_WORKFLOW)(status_module.show_status)
+app.command("sprints", rich_help_panel=PANEL_WORKFLOW)(status_module.list_sprints)
+
+# Setup - project configuration
+app.command("init", rich_help_panel=PANEL_SETUP)(init_module.init_project)
+
+# Utilities - less common operations
+app.command("validate", rich_help_panel=PANEL_UTILITIES)(utils_module.validate_sprint)
+app.command("reset", rich_help_panel=PANEL_UTILITIES)(utils_module.reset_sprint)
+app.command("models", rich_help_panel=PANEL_UTILITIES)(status_module.show_models)
+app.command("hook", rich_help_panel=PANEL_UTILITIES)(hook_module.run_hook)
 
 # Register command groups
-app.add_typer(config_module.config_app, name="config")
-app.add_typer(spec_module.spec_app, name="spec")
+app.add_typer(config_module.config_app, name="config", rich_help_panel=PANEL_UTILITIES)
+app.add_typer(spec_module.spec_app, name="spec", rich_help_panel=PANEL_SETUP)
 
 
 if __name__ == "__main__":

--- a/claudesprint/commands/demo.py
+++ b/claudesprint/commands/demo.py
@@ -1,0 +1,232 @@
+"""Demo command for trying ClaudeSprint with a sample project."""
+
+from importlib import resources
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.panel import Panel
+
+from claudesprint.commands._shared import (
+    console,
+    success,
+    error,
+    warning,
+    info,
+    success_icon,
+    error_icon,
+    warning_icon,
+)
+
+
+def _get_demo_spec_content() -> str:
+    """Load demo spec from package templates."""
+    try:
+        return resources.files("claudesprint.templates.specs").joinpath("demo.md").read_text()
+    except Exception:
+        # Fallback for older Python or missing resource
+        template_path = Path(__file__).parent.parent / "templates" / "specs" / "demo.md"
+        return template_path.read_text()
+
+
+def demo(
+    directory: Annotated[
+        str | None,
+        typer.Option("--dir", "-d", help="Directory for demo project (default: ./claudesprint-demo)"),
+    ] = None,
+    skip_run: Annotated[
+        bool,
+        typer.Option("--skip-run", help="Set up demo but don't run the workflow"),
+    ] = False,
+    clean: Annotated[
+        bool,
+        typer.Option("--clean", help="Remove existing demo directory first"),
+    ] = False,
+) -> None:
+    """Try ClaudeSprint with a sample project.
+
+    Creates a simple demo project to see ClaudeSprint in action without
+    having to write your own spec. Perfect for first-time users.
+
+    The demo creates a "Hello World" CLI tool with 2 simple issues.
+    """
+    import os
+    import shutil
+
+    # Lazy imports for speed
+    from claudesprint.services.health_check_service import HealthCheckService, CheckStatus
+
+    demo_dir = Path(directory) if directory else Path.cwd() / "claudesprint-demo"
+
+    console.print(Panel.fit("[bold cyan]ClaudeSprint Demo[/bold cyan]", border_style="cyan"))
+    console.print("")
+
+    # Check prerequisites first
+    console.print("[bold]Checking prerequisites...[/bold]")
+
+    health_service = HealthCheckService(Path.cwd())
+
+    # Check Claude CLI
+    claude_result = health_service.check_claude_cli()
+    if claude_result.status == CheckStatus.ERROR:
+        console.print(f"  {error_icon()} {claude_result.message}")
+        console.print("")
+        console.print(error("Claude CLI is required for the demo."))
+        console.print("Install from: https://docs.anthropic.com/en/docs/claude-code")
+        raise typer.Exit(1)
+    console.print(f"  {success_icon()} Claude CLI installed")
+
+    # Check auth
+    auth_result = health_service.check_claude_auth()
+    if auth_result.status == CheckStatus.ERROR:
+        console.print(f"  {error_icon()} {auth_result.message}")
+        console.print("")
+        console.print(error("Claude CLI must be authenticated."))
+        console.print(f"Run: {info('claude login')}")
+        raise typer.Exit(1)
+    console.print(f"  {success_icon()} Claude CLI authenticated")
+    console.print("")
+
+    # Handle existing directory
+    if demo_dir.exists():
+        if clean:
+            console.print(f"Removing existing demo directory: {demo_dir}")
+            shutil.rmtree(demo_dir)
+        else:
+            console.print(warning(f"Demo directory already exists: {demo_dir}"))
+            console.print("")
+            console.print("Options:")
+            console.print(f"  • Run with {info('--clean')} to remove and recreate")
+            console.print(f"  • Use {info('--dir <path>')} for a different location")
+            console.print(f"  • Navigate into it: {info(f'cd {demo_dir} && claudesprint run')}")
+            raise typer.Exit(1)
+
+    # Create demo project
+    console.print(f"[bold]Creating demo project in:[/bold] {demo_dir}")
+    console.print("")
+
+    demo_dir.mkdir(parents=True, exist_ok=True)
+
+    # Initialize .claudesprint structure
+    claudesprint_dir = demo_dir / ".claudesprint"
+    (claudesprint_dir / "state").mkdir(parents=True, exist_ok=True)
+    (claudesprint_dir / "prompts").mkdir(parents=True, exist_ok=True)
+    (claudesprint_dir / "specs").mkdir(parents=True, exist_ok=True)
+    (claudesprint_dir / "sprints").mkdir(parents=True, exist_ok=True)
+
+    # Write demo spec
+    spec_path = claudesprint_dir / "specs" / "hello-world.md"
+    spec_path.write_text(_get_demo_spec_content())
+    console.print(f"  {success_icon()} Created demo spec")
+
+    # Create a minimal README
+    readme_content = """# ClaudeSprint Demo Project
+
+This is a demo project created by `claudesprint demo`.
+
+## What's in here
+
+- `.claudesprint/specs/hello-world.md` - The project specification
+- `.claudesprint/sprints/` - Sprint data (after init)
+
+## Next steps
+
+```bash
+cd claudesprint-demo
+claudesprint status      # See sprint status
+claudesprint run         # Continue the workflow
+```
+
+## Clean up
+
+Delete this entire directory when done:
+```bash
+rm -rf claudesprint-demo
+```
+"""
+    (demo_dir / "README.md").write_text(readme_content)
+    console.print(f"  {success_icon()} Created README.md")
+
+    # Initialize git repo
+    try:
+        import subprocess
+        subprocess.run(
+            ["git", "init"],
+            cwd=demo_dir,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "add", "."],
+            cwd=demo_dir,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial demo setup"],
+            cwd=demo_dir,
+            capture_output=True,
+            check=True,
+        )
+        console.print(f"  {success_icon()} Initialized git repository")
+    except (subprocess.SubprocessError, FileNotFoundError):
+        console.print(f"  {warning_icon()} Could not initialize git (optional)")
+
+    console.print("")
+
+    if skip_run:
+        console.print(Panel.fit(
+            f"[bold green]Demo project created![/bold green]\n\n"
+            f"Location: {demo_dir}\n\n"
+            f"[bold]Next steps:[/bold]\n"
+            f"  cd {demo_dir}\n"
+            f"  claudesprint init --spec hello-world\n"
+            f"  claudesprint run",
+            border_style="green",
+        ))
+        return
+
+    # Change to demo directory and initialize sprint
+    original_cwd = Path.cwd()
+    os.chdir(demo_dir)
+
+    try:
+        console.print("[bold]Initializing sprint from spec...[/bold]")
+        console.print("")
+
+        # Import and run init
+        from claudesprint.commands.init import init_project
+
+        # Call init with the demo spec
+        try:
+            init_project(spec="hello-world")
+        except typer.Exit as e:
+            if e.exit_code != 0:
+                console.print(error("Sprint initialization failed"))
+                raise
+        except SystemExit as e:
+            if e.code != 0:
+                console.print(error("Sprint initialization failed"))
+                raise typer.Exit(1)
+
+        console.print("")
+        console.print(Panel.fit(
+            f"[bold green]Demo ready![/bold green]\n\n"
+            f"Location: {demo_dir}\n\n"
+            f"[bold]Start the workflow:[/bold]\n"
+            f"  claudesprint run\n\n"
+            f"[bold]Or run with limits:[/bold]\n"
+            f"  claudesprint run -n 5  [dim]# Max 5 iterations[/dim]",
+            border_style="green",
+        ))
+
+        # Offer to start run
+        console.print("")
+        start_run = typer.confirm("Start the workflow now?", default=False)
+        if start_run:
+            console.print("")
+            from claudesprint.commands.run import run_workflow
+            run_workflow(max_iterations=10)  # Reasonable limit for demo
+
+    finally:
+        os.chdir(original_cwd)

--- a/claudesprint/commands/doctor.py
+++ b/claudesprint/commands/doctor.py
@@ -22,6 +22,39 @@ from claudesprint.commands._shared import (
 )
 
 
+def _display_check_results(checks: list, verbose: bool) -> None:
+    """Display a list of check results with proper formatting.
+
+    Args:
+        checks: List of CheckResult objects.
+        verbose: Whether to show detailed information.
+    """
+    # Import locally to avoid circular imports
+    from claudesprint.services.health_check_service import CheckStatus
+
+    for check in checks:
+        if check.status == CheckStatus.OK:
+            icon = success_icon()
+            message = check.message
+        elif check.status == CheckStatus.WARNING:
+            icon = warning_icon()
+            message = f"[{COLORS.WARNING}]{check.message}[/{COLORS.WARNING}]"
+            # Add fix hint for warnings
+            if check.fix_command:
+                message += f" → {info(check.fix_command)}"
+        else:
+            icon = error_icon()
+            message = f"[{COLORS.ERROR}]{check.message}[/{COLORS.ERROR}]"
+            if check.fix_command:
+                message += f" → {info(check.fix_command)}"
+
+        console.print(f"  {icon} {check.name}: {message}")
+
+        if verbose and check.details:
+            for line in check.details.split("\n"):
+                console.print(f"      {muted(line)}")
+
+
 def doctor(
     verbose: Annotated[
         bool,
@@ -61,23 +94,19 @@ def doctor(
     # Run all checks
     report = service.run_all_checks(verbose=verbose)
 
-    # Display results
-    for check in report.checks:
-        if check.status == CheckStatus.OK:
-            icon = success_icon()
-            message = check.message
-        elif check.status == CheckStatus.WARNING:
-            icon = warning_icon()
-            message = f"[{COLORS.WARNING}]{check.message}[/{COLORS.WARNING}]"
-        else:
-            icon = error_icon()
-            message = f"[{COLORS.ERROR}]{check.message}[/{COLORS.ERROR}]"
+    # Display Environment section
+    console.print(f"[bold]=== Environment ===[/bold]")
+    _display_check_results(report.checks, verbose)
 
-        console.print(f"  {icon} {check.name}: {message}")
+    # Run and display Setup Readiness section
+    console.print("")
+    console.print(f"[bold]=== Setup Readiness ===[/bold]")
+    setup_report = service.run_setup_checks(verbose=verbose)
+    _display_check_results(setup_report.checks, verbose)
 
-        if verbose and check.details:
-            for line in check.details.split("\n"):
-                console.print(f"      {muted(line)}")
+    # Merge setup checks into main report for summary
+    for check in setup_report.checks:
+        report.add(check)
 
     console.print("")
 

--- a/claudesprint/commands/init.py
+++ b/claudesprint/commands/init.py
@@ -1,4 +1,4 @@
-"""Init commands: init (project), plan."""
+"""Init command - create sprint from spec file."""
 
 from pathlib import Path
 from typing import Annotated, Optional
@@ -13,7 +13,6 @@ from claudesprint.commands._shared import (
     success,
     error,
     warning,
-    running,
     subprocess_line,
     muted,
 )
@@ -21,13 +20,9 @@ from claudesprint.commands._shared import (
 
 def init_project(
     spec: Annotated[
-        Optional[str],
-        typer.Option("--spec", "-s", help="Spec file to create sprint from"),
-    ] = None,
-    goal: Annotated[
-        Optional[str],
-        typer.Option("--goal", "-g", help="Quick goal description (creates minimal spec automatically)"),
-    ] = None,
+        str,
+        typer.Option("--spec", "-s", help="Spec file or spec ID to create sprint from"),
+    ],
     description: Annotated[
         Optional[str],
         typer.Option("--description", "-d", help="Sprint description"),
@@ -45,11 +40,14 @@ def init_project(
     Creates a new sprint.json in .claudesprint/sprints/<spec_id>/ and invokes
     the init agent to populate it with issues from the spec.
 
-    Use --spec to provide an existing spec file, or --goal for quick inline specs.
+    Examples:
+        claudesprint init --spec my-project
+        claudesprint init --spec .claudesprint/specs/feature.md
     """
     # Lazy imports for faster startup
     from claudesprint.core.claude_runner import ClaudeRunner
     from claudesprint.services.configuration_manager import ConfigurationManager
+    from claudesprint.services.init_repo_service import InitRepoService
     from claudesprint.services.models_service import ModelsService
     from claudesprint.services.path_service import PathService
     from claudesprint.services.prompt_service import PromptService
@@ -58,70 +56,36 @@ def init_project(
     project_root = get_project_root()
     config = get_config()
 
-    # Validate that either --spec or --goal is provided
-    if spec is None and goal is None:
-        console.print(error("Either --spec or --goal is required"))
-        console.print("")
-        console.print("Usage:")
-        console.print(f"  claudesprint init --spec <spec_file>")
-        console.print(f"  claudesprint init --goal \"Build a TODO app with Express\"")
-        raise typer.Exit(1)
-
-    # Handle --goal option: create a minimal spec automatically
-    if goal is not None:
-        from claudesprint.services.spec_service import SpecService
-
-        spec_service = SpecService(project_root)
-
-        # Generate a spec name from the goal
-        import re
-        goal_slug = re.sub(r"[^a-z0-9]+", "-", goal.lower())[:30].strip("-")
-        spec_name = f"goal-{goal_slug}" if goal_slug else "goal-spec"
-
-        # Create minimal spec content
-        spec_content = f"""# {goal}
-
-## Overview
-
-{goal}
-
-## Issues
-
-### Issue 1: Implement the Goal
-
-{goal}
-
-**Acceptance Criteria:**
-- The implementation meets the stated goal
-- Code is functional and tested
-"""
-
-        # Ensure specs directory exists
-        spec_service.specs_dir.mkdir(parents=True, exist_ok=True)
-
-        # Write the spec
-        spec_path = spec_service.specs_dir / f"{spec_name}.md"
-        spec_path.write_text(spec_content)
-
-        console.print(success(f"Created quick spec: {spec_path.relative_to(project_root)}"))
-        console.print("")
-    else:
-        # Find spec file (original behavior)
-        spec_path = Path(spec)
-        if not spec_path.exists():
-            # Try looking in .claudesprint/specs/
-            spec_path = Path(config.specs_dir) / spec
-            if not spec_path.exists():
-                # Try adding .md extension
-                spec_path = Path(config.specs_dir) / f"{spec}.md"
-
-        if not spec_path.exists():
-            console.print(error(f"Spec file not found: {spec}"))
-            console.print("Looked in:")
-            console.print(f"  • {spec}")
-            console.print(f"  • .claudesprint/specs/{spec}")
-            console.print(f"  • .claudesprint/specs/{spec}.md")
+    # Auto-initialize .claudesprint/ if needed
+    init_service = InitRepoService(project_root)
+    if not init_service.exists():
+        console.print(muted("Initializing .claudesprint/ directory..."))
+        result = init_service.init(force=False, inject_hooks=True)
+        if not result.success:
+            console.print(error(f"Failed to initialize: {result.error}"))
             raise typer.Exit(1)
+        console.print(success("Created .claudesprint/ directory"))
+        console.print("")
+
+    # Find spec file
+    spec_path = Path(spec)
+    if not spec_path.exists():
+        # Try looking in .claudesprint/specs/
+        spec_path = Path(config.specs_dir) / spec
+        if not spec_path.exists():
+            # Try adding .md extension
+            spec_path = Path(config.specs_dir) / f"{spec}.md"
+
+    if not spec_path.exists():
+        console.print(error(f"Spec file not found: {spec}"))
+        console.print("Looked in:")
+        console.print(f"  - {spec}")
+        console.print(f"  - .claudesprint/specs/{spec}")
+        console.print(f"  - .claudesprint/specs/{spec}.md")
+        console.print("")
+        console.print("Create a spec first:")
+        console.print("  claudesprint spec create")
+        raise typer.Exit(1)
 
     sprint_service = SprintService(config.sprints_dir)
     # Convert to relative path for storage
@@ -216,66 +180,4 @@ Read the spec file and populate the sprint.json with all required issues.
         console.print(error(f"Init agent failed (exit code: {result.exit_code})"))
         if result.rate_limited:
             console.print(warning("Rate limit detected. Please wait and try again."))
-        raise typer.Exit(1)
-
-
-def run_planner(
-    spec: Annotated[
-        Optional[str],
-        typer.Option("--spec", "-s", help="Spec ID to plan for"),
-    ] = None,
-    debug_conversations: Annotated[
-        bool,
-        typer.Option(
-            "--debug-conversations",
-            help="Log raw agent inputs/outputs to agent_conversations.log",
-        ),
-    ] = False,
-) -> None:
-    """Run planning mode to generate issues from a spec file."""
-    # Lazy imports for faster startup
-    from claudesprint.core.claude_runner import ClaudeRunner
-    from claudesprint.services.configuration_manager import ConfigurationManager
-    from claudesprint.services.models_service import ModelsService
-    from claudesprint.services.path_service import PathService
-    from claudesprint.services.prompt_service import PromptService
-
-    project_root = get_project_root()
-    config = get_config()
-
-    # Load prompt from package resources via PromptService
-    path_service = PathService(project_root=project_root)
-    prompt_service = PromptService(path_service, project_root=project_root)
-    try:
-        prompt_content = prompt_service.get_prompt_content("plan")
-    except FileNotFoundError:
-        console.print(error("PROMPT_plan.xml.j2 not found in package"))
-        raise typer.Exit(1)
-
-    # Get model for plan step
-    cm = ConfigurationManager(project_root)
-    models_service = ModelsService.from_config_manager(cm)
-    model = models_service.get_model_for_special_step("plan")
-
-    console.print(running(f"Running planner (model: {model})..."))
-
-    runner = ClaudeRunner(
-        project_root,
-        config.claude_timeout,
-        kill_timeout=config.kill_timeout,
-        conversation_log_file=(
-            config.conversation_log_file if debug_conversations else None
-        ),
-    )
-    result = runner.run_with_content(
-        prompt_content,
-        source_name="PROMPT_plan.xml.j2",
-        on_output=lambda line: console.print(subprocess_line(line)),
-        model=model,
-    )
-
-    if result.exit_code == 0:
-        console.print(success("Planning complete."))
-    else:
-        console.print(error(f"Planning failed (exit code: {result.exit_code})"))
         raise typer.Exit(1)

--- a/claudesprint/commands/init.py
+++ b/claudesprint/commands/init.py
@@ -21,9 +21,13 @@ from claudesprint.commands._shared import (
 
 def init_project(
     spec: Annotated[
-        str,
+        Optional[str],
         typer.Option("--spec", "-s", help="Spec file to create sprint from"),
-    ],
+    ] = None,
+    goal: Annotated[
+        Optional[str],
+        typer.Option("--goal", "-g", help="Quick goal description (creates minimal spec automatically)"),
+    ] = None,
     description: Annotated[
         Optional[str],
         typer.Option("--description", "-d", help="Sprint description"),
@@ -40,6 +44,8 @@ def init_project(
 
     Creates a new sprint.json in .claudesprint/sprints/<spec_id>/ and invokes
     the init agent to populate it with issues from the spec.
+
+    Use --spec to provide an existing spec file, or --goal for quick inline specs.
     """
     # Lazy imports for faster startup
     from claudesprint.core.claude_runner import ClaudeRunner
@@ -52,22 +58,70 @@ def init_project(
     project_root = get_project_root()
     config = get_config()
 
-    # Find spec file
-    spec_path = Path(spec)
-    if not spec_path.exists():
-        # Try looking in .claudesprint/specs/
-        spec_path = Path(config.specs_dir) / spec
-        if not spec_path.exists():
-            # Try adding .md extension
-            spec_path = Path(config.specs_dir) / f"{spec}.md"
-
-    if not spec_path.exists():
-        console.print(error(f"Spec file not found: {spec}"))
-        console.print("Looked in:")
-        console.print(f"  • {spec}")
-        console.print(f"  • .claudesprint/specs/{spec}")
-        console.print(f"  • .claudesprint/specs/{spec}.md")
+    # Validate that either --spec or --goal is provided
+    if spec is None and goal is None:
+        console.print(error("Either --spec or --goal is required"))
+        console.print("")
+        console.print("Usage:")
+        console.print(f"  claudesprint init --spec <spec_file>")
+        console.print(f"  claudesprint init --goal \"Build a TODO app with Express\"")
         raise typer.Exit(1)
+
+    # Handle --goal option: create a minimal spec automatically
+    if goal is not None:
+        from claudesprint.services.spec_service import SpecService
+
+        spec_service = SpecService(project_root)
+
+        # Generate a spec name from the goal
+        import re
+        goal_slug = re.sub(r"[^a-z0-9]+", "-", goal.lower())[:30].strip("-")
+        spec_name = f"goal-{goal_slug}" if goal_slug else "goal-spec"
+
+        # Create minimal spec content
+        spec_content = f"""# {goal}
+
+## Overview
+
+{goal}
+
+## Issues
+
+### Issue 1: Implement the Goal
+
+{goal}
+
+**Acceptance Criteria:**
+- The implementation meets the stated goal
+- Code is functional and tested
+"""
+
+        # Ensure specs directory exists
+        spec_service.specs_dir.mkdir(parents=True, exist_ok=True)
+
+        # Write the spec
+        spec_path = spec_service.specs_dir / f"{spec_name}.md"
+        spec_path.write_text(spec_content)
+
+        console.print(success(f"Created quick spec: {spec_path.relative_to(project_root)}"))
+        console.print("")
+    else:
+        # Find spec file (original behavior)
+        spec_path = Path(spec)
+        if not spec_path.exists():
+            # Try looking in .claudesprint/specs/
+            spec_path = Path(config.specs_dir) / spec
+            if not spec_path.exists():
+                # Try adding .md extension
+                spec_path = Path(config.specs_dir) / f"{spec}.md"
+
+        if not spec_path.exists():
+            console.print(error(f"Spec file not found: {spec}"))
+            console.print("Looked in:")
+            console.print(f"  • {spec}")
+            console.print(f"  • .claudesprint/specs/{spec}")
+            console.print(f"  • .claudesprint/specs/{spec}.md")
+            raise typer.Exit(1)
 
     sprint_service = SprintService(config.sprints_dir)
     # Convert to relative path for storage

--- a/claudesprint/commands/initrepo.py
+++ b/claudesprint/commands/initrepo.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from rich.panel import Panel
 
 from claudesprint.commands._shared import (
     console,
@@ -11,6 +12,7 @@ from claudesprint.commands._shared import (
     error,
     warning,
     muted,
+    info,
 )
 
 
@@ -76,7 +78,13 @@ def init_repo(
             console.print(warning("Claude hooks were not injected"))
 
     console.print("")
-    console.print("[bold]Next steps:[/bold]")
-    console.print("  1. Create a spec file in .claudesprint/specs/")
-    console.print("  2. Run: claudesprint init --spec <spec_file>")
-    console.print("  3. Run: claudesprint run")
+    next_steps = (
+        "[bold]Next Steps[/bold]\n\n"
+        "[bold cyan]Quickstart (Recommended):[/bold cyan]\n"
+        f"  {info('claudesprint quickstart')}\n\n"
+        "[bold]Manual Setup:[/bold]\n"
+        f"  1. {info('claudesprint spec create')} - Create a project spec\n"
+        f"  2. {info('claudesprint init --spec <file>')} - Initialize sprint\n"
+        f"  3. {info('claudesprint run')} - Start the workflow"
+    )
+    console.print(Panel(next_steps, border_style="blue"))

--- a/claudesprint/commands/quickstart.py
+++ b/claudesprint/commands/quickstart.py
@@ -9,12 +9,9 @@ from rich.panel import Panel
 from claudesprint.commands._shared import (
     console,
     get_config,
-    ConsoleThrobber,
     STYLES,
-    success,
     error,
     warning,
-    muted,
     info,
     success_icon,
     error_icon,
@@ -202,105 +199,30 @@ def quickstart(
 
     console.print("")
 
-    # Step 4: Initialize sprint
+    # Step 4: Initialize sprint (delegates to init command)
     console.print("[bold][4/4] Initializing sprint...[/bold]")
+    console.print("")
 
-    # Import init components lazily
-    from claudesprint.core.claude_runner import ClaudeRunner
-    from claudesprint.services.configuration_manager import ConfigurationManager
-    from claudesprint.services.models_service import ModelsService
-    from claudesprint.services.path_service import PathService
-    from claudesprint.services.prompt_service import PromptService
+    from claudesprint.commands.init import init_project
+
+    try:
+        init_project(spec=spec_name, description=description or "")
+    except typer.Exit as e:
+        if e.exit_code != 0:
+            raise
+    except SystemExit as e:
+        if e.code != 0:
+            raise typer.Exit(1)
+
+    # Get sprint info for summary
     from claudesprint.services.sprint_service import SprintService
 
     config = get_config()
-
-    # Create sprint from spec
     sprint_service = SprintService(config.sprints_dir)
-    try:
-        relative_spec_path = spec_path.relative_to(project_root)
-    except ValueError:
-        relative_spec_path = spec_path
-
-    sprint_path, sprint = sprint_service.create_sprint_from_spec(
-        relative_spec_path, description or ""
-    )
-
-    # Ensure sprints directory exists
-    sprint_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Write sprint skeleton
-    if not sprint_service.write_sprint(sprint, sprint_path):
-        console.print(f"  {error_icon()} Failed to create sprint")
-        raise typer.Exit(1)
-
-    console.print(f"  {success_icon()} Sprint skeleton created")
-
-    # Load init prompt
-    path_service = PathService(project_root=project_root)
-    prompt_service = PromptService(path_service, project_root=project_root)
-    try:
-        prompt_content = prompt_service.get_prompt_content("init")
-    except FileNotFoundError:
-        console.print(f"  {error_icon()} Init prompt template not found")
-        raise typer.Exit(1)
-
-    # Get model for init step
-    cm = ConfigurationManager(project_root)
-    models_service = ModelsService.from_config_manager(cm)
-    model = models_service.get_model_for_special_step("init")
-
-    # Build context for the agent
-    context = f"""## Initialization Context
-
-You are initializing a sprint for:
-- **Spec ID**: {sprint.spec_id}
-- **Spec file**: {relative_spec_path}
-- **Sprint file**: {sprint_path.relative_to(project_root)}
-
-Read the spec file and populate the sprint.json with all required issues.
-
----"""
-
-    runner = ClaudeRunner(
-        project_root,
-        config.claude_timeout,
-        kill_timeout=config.kill_timeout,
-    )
-
-    # Run init agent with throbber
-    throbber = ConsoleThrobber(console)
-    throbber.start(f"  Generating issues from spec (model: {model})")
-    first_output_received = [False]
-
-    def on_output(line: str) -> None:
-        if not first_output_received[0]:
-            first_output_received[0] = True
-            throbber.stop()
-        # Don't show verbose output in quickstart
-
-    result = runner.run_with_content(
-        prompt_content,
-        source_name="PROMPT_init.xml.j2",
-        on_output=on_output,
-        model=model,
-        context=context,
-    )
-
-    if throbber.is_running:
-        throbber.stop()
-
-    if result.exit_code != 0:
-        console.print(f"  {error_icon()} Sprint initialization failed")
-        if result.rate_limited:
-            console.print(warning("  Rate limit detected. Please wait and try again."))
-        raise typer.Exit(1)
-
-    # Count issues in sprint
-    updated_sprint = sprint_service.read_sprint(sprint_path)
-    issue_count = len(updated_sprint.issues) if updated_sprint else 0
-
-    console.print(f"  {success_icon()} Sprint ready with {issue_count} issue(s)")
+    sprint_path = sprint_service.get_sprint_path(spec_name)
+    sprint = sprint_service.read_sprint(sprint_path)
+    issue_count = len(sprint.issues) if sprint else 0
+    spec_id = sprint.spec_id if sprint else spec_name
 
     console.print("")
 
@@ -321,14 +243,11 @@ Read the spec file and populate the sprint.json with all required issues.
         start_run = typer.confirm("Start the sprint now?", default=False)
         if start_run:
             console.print("")
-            console.print(f"Starting: {info(f'claudesprint run --spec {sprint.spec_id}')}")
-            console.print("")
-            # Import and call run command
             from claudesprint.commands.run import run_workflow
-            # We need to exit and re-invoke since run_workflow takes control
-            raise typer.Exit(0)
+            run_workflow(spec=spec_id)
 
-    # Show next steps
-    console.print("[bold]Next steps:[/bold]")
-    console.print(f"  1. Review spec:  {info(f'claudesprint spec show {spec_name}')}")
-    console.print(f"  2. Start sprint: {info(f'claudesprint run --spec {sprint.spec_id}')}")
+    # Show next steps if not starting run
+    if skip_run or non_interactive:
+        console.print("[bold]Next steps:[/bold]")
+        console.print(f"  1. Review spec:  {info(f'claudesprint spec show {spec_name}')}")
+        console.print(f"  2. Start sprint: {info(f'claudesprint run --spec {spec_id}')}")

--- a/claudesprint/commands/quickstart.py
+++ b/claudesprint/commands/quickstart.py
@@ -1,0 +1,334 @@
+"""Quickstart command for single-command project setup."""
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.panel import Panel
+
+from claudesprint.commands._shared import (
+    console,
+    get_config,
+    ConsoleThrobber,
+    STYLES,
+    success,
+    error,
+    warning,
+    muted,
+    info,
+    success_icon,
+    error_icon,
+    warning_icon,
+)
+
+
+def quickstart(
+    template: Annotated[
+        str | None,
+        typer.Option("--template", "-t", help="Template to use (web-application, cli-tool, api-service, minimal)"),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option("--name", "-n", help="Project name"),
+    ] = None,
+    description: Annotated[
+        str | None,
+        typer.Option("--description", "-d", help="Project description"),
+    ] = None,
+    non_interactive: Annotated[
+        bool,
+        typer.Option("--non-interactive", help="Use defaults without prompting (for CI)"),
+    ] = False,
+    skip_run: Annotated[
+        bool,
+        typer.Option("--skip-run", help="Don't offer to start run after setup"),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", "-f", help="Reinitialize even if .claudesprint/ exists"),
+    ] = False,
+) -> None:
+    """Quick start a new ClaudeSprint project in one command.
+
+    This command guides you through:
+    1. Checking prerequisites (Python, Claude CLI, auth)
+    2. Initializing .claudesprint/ directory
+    3. Creating a project spec from a template
+    4. Initializing the sprint from the spec
+    5. Optionally starting the run workflow
+    """
+    # Lazy imports for faster startup
+    from claudesprint.services.health_check_service import HealthCheckService, CheckStatus
+    from claudesprint.services.init_repo_service import InitRepoService
+    from claudesprint.services.spec_service import SpecService
+
+    project_root = Path.cwd()
+
+    console.print(Panel.fit("ClaudeSprint Quickstart", style=STYLES.PANEL_HEADER))
+    console.print("")
+
+    # Step 1: Check prerequisites
+    console.print("[bold][1/4] Checking prerequisites...[/bold]")
+
+    health_service = HealthCheckService(project_root)
+
+    # Check Python version
+    python_result = health_service.check_python_version()
+    if python_result.status == CheckStatus.OK:
+        console.print(f"  {success_icon()} {python_result.message}")
+    else:
+        console.print(f"  {error_icon()} {python_result.message}")
+        raise typer.Exit(1)
+
+    # Check Claude CLI
+    claude_result = health_service.check_claude_cli()
+    if claude_result.status == CheckStatus.OK:
+        console.print(f"  {success_icon()} Claude CLI installed")
+    elif claude_result.status == CheckStatus.ERROR:
+        console.print(f"  {error_icon()} {claude_result.message}")
+        console.print("")
+        console.print(error("Claude CLI is required. Install from:"))
+        console.print(info("  https://docs.anthropic.com/en/docs/claude-code"))
+        raise typer.Exit(1)
+    else:
+        console.print(f"  {warning_icon()} {claude_result.message}")
+
+    # Check Claude auth
+    auth_result = health_service.check_claude_auth()
+    if auth_result.status == CheckStatus.OK:
+        console.print(f"  {success_icon()} Claude CLI authenticated")
+    elif auth_result.status == CheckStatus.ERROR:
+        console.print(f"  {error_icon()} {auth_result.message}")
+        console.print("")
+        console.print(error("Claude CLI is not authenticated."))
+        console.print(f"Run: {info('claude login')}")
+        raise typer.Exit(1)
+    else:
+        console.print(f"  {warning_icon()} {auth_result.message}")
+
+    console.print("")
+
+    # Step 2: Initialize project
+    console.print("[bold][2/4] Initializing project...[/bold]")
+
+    init_service = InitRepoService(project_root)
+
+    if init_service.exists() and not force:
+        console.print(f"  {success_icon()} Project already initialized")
+    else:
+        result = init_service.init(force=force, inject_hooks=True)
+        if not result.success:
+            console.print(f"  {error_icon()} {result.error}")
+            raise typer.Exit(1)
+        console.print(f"  {success_icon()} Created .claudesprint/ directory")
+        if result.hooks_injected:
+            console.print(f"  {success_icon()} Claude hooks configured")
+
+    console.print("")
+
+    # Step 3: Create spec
+    console.print("[bold][3/4] Creating project spec...[/bold]")
+
+    spec_service = SpecService(project_root)
+    templates = spec_service.get_templates()
+
+    # Get project name
+    if name is None:
+        if non_interactive:
+            # Use directory name as default
+            name = project_root.name
+            console.print(f"  Using directory name: {name}")
+        else:
+            name = typer.prompt("  Project name", default=project_root.name)
+
+    # Get template
+    if template is None:
+        if non_interactive:
+            template = "minimal"
+            console.print(f"  Using template: {template}")
+        else:
+            console.print("")
+            console.print("  [bold]Available templates:[/bold]")
+            for i, t in enumerate(templates, 1):
+                console.print(f"    [{i}] {t.display_name} - {t.description}")
+            console.print("")
+
+            while True:
+                choice = typer.prompt(f"  Select template [1-{len(templates)}]", default="1")
+                try:
+                    idx = int(choice) - 1
+                    if 0 <= idx < len(templates):
+                        template = templates[idx].name
+                        break
+                    console.print(warning(f"  Please enter a number between 1 and {len(templates)}"))
+                except ValueError:
+                    # Check if user typed template name directly
+                    for t in templates:
+                        if t.name == choice or t.display_name.lower() == choice.lower():
+                            template = t.name
+                            break
+                    else:
+                        console.print(warning("  Invalid selection."))
+                        continue
+                    break
+    else:
+        # Validate template exists
+        valid_templates = [t.name for t in templates]
+        if template not in valid_templates:
+            console.print(f"  {error_icon()} Unknown template: {template}")
+            console.print(f"  Available: {', '.join(valid_templates)}")
+            raise typer.Exit(1)
+
+    # Get description
+    if description is None:
+        if non_interactive:
+            description = ""
+        else:
+            description = typer.prompt("  Brief description (optional)", default="")
+
+    # Create the spec
+    try:
+        spec_path = spec_service.create_spec(
+            name=name,
+            template=template,
+            project_name=name,
+            description=description,
+        )
+        spec_name = spec_path.stem
+        console.print(f"  {success_icon()} Created spec: {spec_path.relative_to(project_root)}")
+    except (ValueError, OSError) as e:
+        console.print(f"  {error_icon()} Failed to create spec: {e}")
+        raise typer.Exit(1)
+
+    console.print("")
+
+    # Step 4: Initialize sprint
+    console.print("[bold][4/4] Initializing sprint...[/bold]")
+
+    # Import init components lazily
+    from claudesprint.core.claude_runner import ClaudeRunner
+    from claudesprint.services.configuration_manager import ConfigurationManager
+    from claudesprint.services.models_service import ModelsService
+    from claudesprint.services.path_service import PathService
+    from claudesprint.services.prompt_service import PromptService
+    from claudesprint.services.sprint_service import SprintService
+
+    config = get_config()
+
+    # Create sprint from spec
+    sprint_service = SprintService(config.sprints_dir)
+    try:
+        relative_spec_path = spec_path.relative_to(project_root)
+    except ValueError:
+        relative_spec_path = spec_path
+
+    sprint_path, sprint = sprint_service.create_sprint_from_spec(
+        relative_spec_path, description or ""
+    )
+
+    # Ensure sprints directory exists
+    sprint_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write sprint skeleton
+    if not sprint_service.write_sprint(sprint, sprint_path):
+        console.print(f"  {error_icon()} Failed to create sprint")
+        raise typer.Exit(1)
+
+    console.print(f"  {success_icon()} Sprint skeleton created")
+
+    # Load init prompt
+    path_service = PathService(project_root=project_root)
+    prompt_service = PromptService(path_service, project_root=project_root)
+    try:
+        prompt_content = prompt_service.get_prompt_content("init")
+    except FileNotFoundError:
+        console.print(f"  {error_icon()} Init prompt template not found")
+        raise typer.Exit(1)
+
+    # Get model for init step
+    cm = ConfigurationManager(project_root)
+    models_service = ModelsService.from_config_manager(cm)
+    model = models_service.get_model_for_special_step("init")
+
+    # Build context for the agent
+    context = f"""## Initialization Context
+
+You are initializing a sprint for:
+- **Spec ID**: {sprint.spec_id}
+- **Spec file**: {relative_spec_path}
+- **Sprint file**: {sprint_path.relative_to(project_root)}
+
+Read the spec file and populate the sprint.json with all required issues.
+
+---"""
+
+    runner = ClaudeRunner(
+        project_root,
+        config.claude_timeout,
+        kill_timeout=config.kill_timeout,
+    )
+
+    # Run init agent with throbber
+    throbber = ConsoleThrobber(console)
+    throbber.start(f"  Generating issues from spec (model: {model})")
+    first_output_received = [False]
+
+    def on_output(line: str) -> None:
+        if not first_output_received[0]:
+            first_output_received[0] = True
+            throbber.stop()
+        # Don't show verbose output in quickstart
+
+    result = runner.run_with_content(
+        prompt_content,
+        source_name="PROMPT_init.xml.j2",
+        on_output=on_output,
+        model=model,
+        context=context,
+    )
+
+    if throbber.is_running:
+        throbber.stop()
+
+    if result.exit_code != 0:
+        console.print(f"  {error_icon()} Sprint initialization failed")
+        if result.rate_limited:
+            console.print(warning("  Rate limit detected. Please wait and try again."))
+        raise typer.Exit(1)
+
+    # Count issues in sprint
+    updated_sprint = sprint_service.read_sprint(sprint_path)
+    issue_count = len(updated_sprint.issues) if updated_sprint else 0
+
+    console.print(f"  {success_icon()} Sprint ready with {issue_count} issue(s)")
+
+    console.print("")
+
+    # Show success summary
+    console.print(Panel.fit(
+        f"[bold green]Setup Complete![/bold green]\n\n"
+        f"Project: {name}\n"
+        f"Template: {template}\n"
+        f"Issues: {issue_count}\n"
+        f"Sprint: {sprint_path.relative_to(project_root)}",
+        style=STYLES.PANEL_SUCCESS if hasattr(STYLES, 'PANEL_SUCCESS') else "green",
+    ))
+
+    console.print("")
+
+    # Offer to start run
+    if not skip_run and not non_interactive:
+        start_run = typer.confirm("Start the sprint now?", default=False)
+        if start_run:
+            console.print("")
+            console.print(f"Starting: {info(f'claudesprint run --spec {sprint.spec_id}')}")
+            console.print("")
+            # Import and call run command
+            from claudesprint.commands.run import run_workflow
+            # We need to exit and re-invoke since run_workflow takes control
+            raise typer.Exit(0)
+
+    # Show next steps
+    console.print("[bold]Next steps:[/bold]")
+    console.print(f"  1. Review spec:  {info(f'claudesprint spec show {spec_name}')}")
+    console.print(f"  2. Start sprint: {info(f'claudesprint run --spec {sprint.spec_id}')}")

--- a/claudesprint/commands/run.py
+++ b/claudesprint/commands/run.py
@@ -56,12 +56,8 @@ def run_workflow(
     ] = False,
     verbose: Annotated[
         int,
-        typer.Option("-v", "--verbose", count=True, help="Increase verbosity (-v, -vv, -vvv)"),
+        typer.Option("-v", "--verbose", count=True, help="Increase verbosity (-v, -vv)"),
     ] = 0,
-    dashboard: Annotated[
-        bool,
-        typer.Option("--dashboard", help="Start the web dashboard for real-time monitoring"),
-    ] = False,
 ) -> None:
     """Run the sprint workflow loop.
 
@@ -99,7 +95,7 @@ def run_workflow(
             console.print("  claudesprint run --sprint path/to/sprint.json")
             raise typer.Exit(1)
 
-    _run_sprint_console(project_root, config, sprint_path, max_iterations, _get_verbosity(verbose), dashboard)
+    _run_sprint_console(project_root, config, sprint_path, max_iterations, _get_verbosity(verbose))
 
 
 def _run_sprint_console(
@@ -108,7 +104,6 @@ def _run_sprint_console(
     sprint_path: Path,
     max_iterations: int,
     verbosity: LogVerbosity = LogVerbosity.NORMAL,
-    enable_dashboard: bool = False,
 ) -> None:
     """Run the sprint workflow with console output."""
     # Lazy imports - only load heavy modules when actually running
@@ -241,31 +236,9 @@ def _run_sprint_console(
     logs_subscriber = LogsEventSubscriber(output, event_bus)
     logs_subscriber.connect()
 
-    # Start dashboard server (only if explicitly enabled)
-    from claudesprint.dashboard.server import DashboardServer
-
-    dashboard_server: DashboardServer | None = None
-    if enable_dashboard:
-        try:
-            dashboard_server = DashboardServer(event_bus)
-            dashboard_url = dashboard_server.start()
-            if dashboard_url:
-                console.print(f"[cyan]Dashboard: {dashboard_url}[/cyan]")
-        except Exception as e:
-            # Dashboard is optional - log and continue without it
-            import logging
-
-            logging.getLogger(__name__).debug(f"Dashboard failed to start: {e}")
-            dashboard_server = None
-
     # Run sprint
-    try:
-        with output:
-            result = engine.run(max_iterations=max_iterations)
-    finally:
-        # Stop dashboard server
-        if dashboard_server:
-            dashboard_server.stop()
+    with output:
+        result = engine.run(max_iterations=max_iterations)
 
     # Disconnect subscriber after sprint completes
     logs_subscriber.disconnect()

--- a/claudesprint/commands/spec.py
+++ b/claudesprint/commands/spec.py
@@ -1,0 +1,244 @@
+"""Spec command group for managing project specifications."""
+
+from typing import Annotated
+
+import typer
+from rich.panel import Panel
+from rich.table import Table
+
+from claudesprint.commands._shared import (
+    console,
+    get_project_root,
+    STYLES,
+    success,
+    error,
+    warning,
+    muted,
+    info,
+    success_icon,
+    warning_icon,
+    error_icon,
+)
+
+
+# Spec command group
+spec_app = typer.Typer(
+    name="spec",
+    help="Manage project specifications",
+)
+
+
+@spec_app.command("list")
+def spec_list() -> None:
+    """List all spec files in the project."""
+    # Lazy imports
+    from claudesprint.services.spec_service import SpecService
+
+    project_root = get_project_root()
+    service = SpecService(project_root)
+    specs = service.list_specs()
+
+    if not specs:
+        console.print(warning("No spec files found."))
+        console.print("")
+        console.print(f"Create one with: {info('claudesprint spec create')}")
+        return
+
+    console.print(Panel.fit("Spec Files", style=STYLES.PANEL_HEADER))
+    console.print("")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name")
+    table.add_column("Title")
+    table.add_column("Path")
+
+    for spec in specs:
+        title = spec.title or muted("(no title)")
+        # Make path relative to project root
+        rel_path = spec.path.relative_to(project_root)
+        table.add_row(spec.name, title, str(rel_path))
+
+    console.print(table)
+
+
+@spec_app.command("show")
+def spec_show(
+    name: Annotated[str, typer.Argument(help="Name of the spec file to display")],
+) -> None:
+    """Display the contents of a spec file."""
+    # Lazy imports
+    from claudesprint.services.spec_service import SpecService
+
+    project_root = get_project_root()
+    service = SpecService(project_root)
+    content = service.read_spec(name)
+
+    if content is None:
+        console.print(error(f"Spec file '{name}' not found."))
+        console.print("")
+        console.print(f"List available specs with: {info('claudesprint spec list')}")
+        raise typer.Exit(1)
+
+    spec = service.get_spec(name)
+    title = spec.title if spec else name
+
+    console.print(Panel.fit(f"Spec: {title}", style=STYLES.PANEL_HEADER))
+    console.print("")
+    console.print(content)
+
+
+@spec_app.command("validate")
+def spec_validate(
+    name: Annotated[str, typer.Argument(help="Name of the spec file to validate")],
+) -> None:
+    """Validate the structure of a spec file."""
+    # Lazy imports
+    from claudesprint.services.spec_service import SpecService
+
+    project_root = get_project_root()
+    service = SpecService(project_root)
+    result = service.validate_spec(name)
+
+    if not result.valid:
+        console.print(error(f"Validation failed for '{name}'"))
+        console.print("")
+        for err in result.errors:
+            console.print(f"  {error_icon()} {err}")
+        raise typer.Exit(1)
+
+    console.print(success(f"Spec '{name}' is valid"))
+    console.print("")
+
+    if result.title:
+        console.print(f"  Title: {result.title}")
+
+    if result.sections_found:
+        console.print(f"  Sections: {', '.join(result.sections_found)}")
+
+    if result.warnings:
+        console.print("")
+        console.print("[bold]Suggestions:[/bold]")
+        for warn in result.warnings:
+            console.print(f"  {warning_icon()} {warn}")
+
+
+@spec_app.command("create")
+def spec_create(
+    name: Annotated[
+        str | None,
+        typer.Option("--name", "-n", help="Name for the spec file"),
+    ] = None,
+    template: Annotated[
+        str | None,
+        typer.Option("--template", "-t", help="Template to use"),
+    ] = None,
+    description: Annotated[
+        str | None,
+        typer.Option("--description", "-d", help="Project description"),
+    ] = None,
+) -> None:
+    """Create a new spec file from a template.
+
+    If options are not provided, runs in interactive mode.
+    """
+    # Lazy imports
+    from claudesprint.services.spec_service import SpecService
+
+    project_root = get_project_root()
+    service = SpecService(project_root)
+    templates = service.get_templates()
+
+    console.print(Panel.fit("Create New Spec", style=STYLES.PANEL_HEADER))
+    console.print("")
+
+    # Interactive mode for project name
+    if name is None:
+        name = typer.prompt("Project name")
+
+    # Interactive mode for template selection
+    if template is None:
+        console.print("[bold]Available templates:[/bold]")
+        for i, t in enumerate(templates, 1):
+            console.print(f"  [{i}] {t.display_name} - {t.description}")
+        console.print("")
+
+        while True:
+            choice = typer.prompt(f"Select template [1-{len(templates)}]")
+            try:
+                idx = int(choice) - 1
+                if 0 <= idx < len(templates):
+                    template = templates[idx].name
+                    break
+                console.print(warning(f"Please enter a number between 1 and {len(templates)}"))
+            except ValueError:
+                # Check if user typed template name directly
+                for t in templates:
+                    if t.name == choice or t.display_name.lower() == choice.lower():
+                        template = t.name
+                        break
+                else:
+                    console.print(warning("Invalid selection. Enter a number or template name."))
+                    continue
+                break
+    else:
+        # Validate template exists
+        valid_templates = [t.name for t in templates]
+        if template not in valid_templates:
+            console.print(error(f"Unknown template: {template}"))
+            console.print(f"Available templates: {', '.join(valid_templates)}")
+            raise typer.Exit(1)
+
+    # Interactive mode for description
+    if description is None:
+        description = typer.prompt("Brief description (optional)", default="")
+
+    # Create the spec
+    try:
+        spec_path = service.create_spec(
+            name=name,
+            template=template,
+            project_name=name,
+            description=description,
+        )
+
+        console.print("")
+        console.print(success(f"Created: {spec_path.relative_to(project_root)}"))
+        console.print("")
+
+        # Show next steps
+        spec_name = spec_path.stem
+        console.print("[bold]Next steps:[/bold]")
+        console.print(f"  1. Review and customize: {info(f'claudesprint spec show {spec_name}')}")
+        console.print(f"  2. Initialize sprint:    {info(f'claudesprint init --spec {spec_name}')}")
+
+    except ValueError as e:
+        console.print(error(str(e)))
+        raise typer.Exit(1)
+    except OSError as e:
+        console.print(error(f"Failed to create spec: {e}"))
+        raise typer.Exit(1)
+
+
+@spec_app.command("templates")
+def spec_templates() -> None:
+    """List available spec templates."""
+    # Lazy imports
+    from claudesprint.services.spec_service import SpecService
+
+    project_root = get_project_root()
+    service = SpecService(project_root)
+    templates = service.get_templates()
+
+    console.print(Panel.fit("Available Templates", style=STYLES.PANEL_HEADER))
+    console.print("")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name")
+    table.add_column("Description")
+
+    for t in templates:
+        table.add_row(t.name, t.description)
+
+    console.print(table)
+    console.print("")
+    console.print(f"Use with: {info('claudesprint spec create --template <name>')}")

--- a/claudesprint/commands/spec.py
+++ b/claudesprint/commands/spec.py
@@ -217,28 +217,3 @@ def spec_create(
     except OSError as e:
         console.print(error(f"Failed to create spec: {e}"))
         raise typer.Exit(1)
-
-
-@spec_app.command("templates")
-def spec_templates() -> None:
-    """List available spec templates."""
-    # Lazy imports
-    from claudesprint.services.spec_service import SpecService
-
-    project_root = get_project_root()
-    service = SpecService(project_root)
-    templates = service.get_templates()
-
-    console.print(Panel.fit("Available Templates", style=STYLES.PANEL_HEADER))
-    console.print("")
-
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("Name")
-    table.add_column("Description")
-
-    for t in templates:
-        table.add_row(t.name, t.description)
-
-    console.print(table)
-    console.print("")
-    console.print(f"Use with: {info('claudesprint spec create --template <name>')}")

--- a/claudesprint/commands/utils.py
+++ b/claudesprint/commands/utils.py
@@ -1,4 +1,4 @@
-"""Utility commands: validate, reset, notify."""
+"""Utility commands: validate, reset."""
 
 from pathlib import Path
 from typing import Annotated, Optional
@@ -7,7 +7,6 @@ import typer
 
 from claudesprint.commands._shared import (
     console,
-    get_project_root,
     get_config,
     COLORS,
     success,
@@ -106,44 +105,3 @@ def reset_sprint(
         console.print("Run 'claudesprint run' to start fresh.")
     else:
         console.print(warning("No current issue to clear."))
-
-
-def send_notification(
-    notification_type: Annotated[
-        str,
-        typer.Argument(help="Notification type: step, failure, exit, rate_limit"),
-    ],
-    message: Annotated[
-        str,
-        typer.Argument(help="Notification message"),
-    ],
-    title: Annotated[
-        Optional[str],
-        typer.Option("--title", "-t", help="Optional custom title"),
-    ] = None,
-) -> None:
-    """Send a notification via Bark."""
-    # Lazy imports
-    from claudesprint.services.configuration_manager import ConfigurationManager
-    from claudesprint.services.notification_service import NotificationService, NotificationType
-
-    config = get_config()
-    project_root = get_project_root()
-    cm = ConfigurationManager(project_root)
-    service = NotificationService.from_config_manager(
-        cm, http_timeout=config.http_timeout
-    )
-
-    if not service.enabled:
-        console.print(warning("Notifications are not enabled"))
-        return
-
-    try:
-        notif_type = NotificationType(notification_type)
-    except ValueError:
-        console.print(error(f"Invalid type: {notification_type}"))
-        console.print(f"Valid types: {', '.join(t.value for t in NotificationType)}")
-        raise typer.Exit(1)
-
-    service.send_sync(notif_type, message, title)
-    console.print(success("Notification sent"))

--- a/claudesprint/services/constants.py
+++ b/claudesprint/services/constants.py
@@ -180,16 +180,13 @@ claudesprint doctor --fix               # Auto-fix issues
 ### Full sprint workflow
 
 ```bash
-# 1. Initialize repo (first time only)
-claudesprint initrepo
+# 1. Create spec file
+claudesprint spec create
 
-# 2. Create spec file
-# Write your spec to .claudesprint/specs/my-feature.md
+# 2. Initialize sprint from spec
+claudesprint init --spec my-feature
 
-# 3. Initialize sprint from spec
-claudesprint init --spec my-feature.md
-
-# 4. Run the sprint
+# 3. Run the sprint
 claudesprint run
 
 # 5. Monitor progress

--- a/claudesprint/services/health_check_service.py
+++ b/claudesprint/services/health_check_service.py
@@ -145,11 +145,31 @@ class HealthCheckService:
         report.add(self.check_python_version(verbose))
         report.add(self.check_required_packages(verbose))
         report.add(self.check_claude_cli(verbose))
+        report.add(self.check_claude_auth(verbose))
         report.add(self.check_project_structure(verbose))
 
         # Optional checks
         for check in self.check_optional_deps(verbose):
             report.add(check)
+
+        return report
+
+    def run_setup_checks(self, verbose: bool = False) -> HealthReport:
+        """Run setup readiness checks.
+
+        Checks project initialization status, spec files, and sprint status.
+
+        Args:
+            verbose: Include detailed information in results.
+
+        Returns:
+            HealthReport with setup check results.
+        """
+        report = HealthReport()
+
+        report.add(self.check_project_initialized(verbose))
+        report.add(self.check_spec_files(verbose))
+        report.add(self.check_sprint_exists(verbose))
 
         return report
 
@@ -271,6 +291,262 @@ class HealthCheckService:
                 message="Claude CLI found but version check failed",
                 details=f"Path: {claude_path}" if verbose else None,
             )
+
+    def check_claude_auth(self, verbose: bool = False) -> CheckResult:
+        """Check if Claude CLI is authenticated.
+
+        Runs a simple Claude CLI command to verify authentication status.
+
+        Args:
+            verbose: Include authentication details.
+
+        Returns:
+            CheckResult for Claude CLI authentication.
+        """
+        claude_path = shutil.which("claude")
+
+        if not claude_path:
+            return CheckResult(
+                name="Claude CLI Auth",
+                status=CheckStatus.ERROR,
+                message="Claude CLI not installed (cannot check auth)",
+                details="Install Claude CLI first" if verbose else None,
+            )
+
+        try:
+            # Use 'claude api-key' or similar lightweight check
+            # The 'claude --version' works but doesn't test auth
+            # Try using 'claude config list' which requires auth
+            result = subprocess.run(
+                ["claude", "config", "list"],
+                capture_output=True,
+                text=True,
+                timeout=self.version_check_timeout,
+            )
+
+            if result.returncode == 0:
+                return CheckResult(
+                    name="Claude CLI Auth",
+                    status=CheckStatus.OK,
+                    message="Claude CLI authenticated",
+                    details=f"Config available" if verbose else None,
+                )
+            else:
+                # Check for specific auth error messages
+                error_output = result.stderr.lower()
+                if "not logged in" in error_output or "auth" in error_output:
+                    return CheckResult(
+                        name="Claude CLI Auth",
+                        status=CheckStatus.ERROR,
+                        message="Claude CLI not authenticated",
+                        details=(
+                            "Run 'claude login' to authenticate with your Anthropic account"
+                            if verbose
+                            else None
+                        ),
+                        fixable=False,
+                        fix_command="claude login",
+                    )
+                else:
+                    return CheckResult(
+                        name="Claude CLI Auth",
+                        status=CheckStatus.WARNING,
+                        message="Claude CLI auth status unclear",
+                        details=(
+                            f"Check manually with 'claude config list'\nError: {result.stderr.strip()}"
+                            if verbose
+                            else None
+                        ),
+                    )
+        except subprocess.TimeoutExpired:
+            return CheckResult(
+                name="Claude CLI Auth",
+                status=CheckStatus.WARNING,
+                message="Auth check timed out",
+                details="Claude CLI may be unresponsive" if verbose else None,
+            )
+        except (subprocess.SubprocessError, OSError) as e:
+            return CheckResult(
+                name="Claude CLI Auth",
+                status=CheckStatus.WARNING,
+                message="Could not check auth status",
+                details=str(e) if verbose else None,
+            )
+
+    def check_project_initialized(self, verbose: bool = False) -> CheckResult:
+        """Check if project has been initialized with ClaudeSprint.
+
+        Args:
+            verbose: Include directory details.
+
+        Returns:
+            CheckResult for project initialization.
+        """
+        claudesprint_dir = self.project_root / ".claudesprint"
+
+        if not claudesprint_dir.exists():
+            return CheckResult(
+                name="Project Initialized",
+                status=CheckStatus.WARNING,
+                message="Project not initialized",
+                details=(
+                    "Run 'claudesprint quickstart' or 'claudesprint initrepo' to initialize"
+                    if verbose
+                    else None
+                ),
+                fixable=True,
+                fix_command="claudesprint initrepo",
+            )
+
+        # Check for essential directories
+        state_dir = claudesprint_dir / "state"
+        if not state_dir.exists():
+            return CheckResult(
+                name="Project Initialized",
+                status=CheckStatus.WARNING,
+                message="Project partially initialized (missing state/)",
+                details="Run 'claudesprint initrepo' to complete setup" if verbose else None,
+                fixable=True,
+                fix_command="claudesprint initrepo",
+            )
+
+        return CheckResult(
+            name="Project Initialized",
+            status=CheckStatus.OK,
+            message="Project initialized",
+            details=f"Directory: {claudesprint_dir}" if verbose else None,
+        )
+
+    def check_spec_files(self, verbose: bool = False) -> CheckResult:
+        """Check if spec files exist.
+
+        Args:
+            verbose: Include list of spec files.
+
+        Returns:
+            CheckResult for spec files.
+        """
+        claudesprint_dir = self.project_root / ".claudesprint"
+        specs_dir = claudesprint_dir / "specs"
+
+        if not claudesprint_dir.exists():
+            return CheckResult(
+                name="Spec Files",
+                status=CheckStatus.WARNING,
+                message="Project not initialized (no specs)",
+                details="Initialize project first" if verbose else None,
+            )
+
+        if not specs_dir.exists():
+            # Also check for .md files directly in .claudesprint
+            md_files = list(claudesprint_dir.glob("*.md"))
+            if md_files:
+                return CheckResult(
+                    name="Spec Files",
+                    status=CheckStatus.OK,
+                    message=f"{len(md_files)} spec file(s) found",
+                    details="\n".join(f.name for f in md_files) if verbose else None,
+                )
+            return CheckResult(
+                name="Spec Files",
+                status=CheckStatus.WARNING,
+                message="No spec files found",
+                details=(
+                    "Create with: claudesprint spec create"
+                    if verbose
+                    else None
+                ),
+                fixable=False,
+                fix_command="claudesprint spec create",
+            )
+
+        # Check for spec files in specs directory
+        spec_files = list(specs_dir.glob("*.md"))
+        # Also include .md files in root .claudesprint
+        spec_files.extend(list(claudesprint_dir.glob("*.md")))
+
+        if not spec_files:
+            return CheckResult(
+                name="Spec Files",
+                status=CheckStatus.WARNING,
+                message="No spec files found",
+                details=(
+                    "Create with: claudesprint spec create"
+                    if verbose
+                    else None
+                ),
+                fixable=False,
+                fix_command="claudesprint spec create",
+            )
+
+        return CheckResult(
+            name="Spec Files",
+            status=CheckStatus.OK,
+            message=f"{len(spec_files)} spec file(s) found",
+            details="\n".join(f.name for f in spec_files) if verbose else None,
+        )
+
+    def check_sprint_exists(self, verbose: bool = False) -> CheckResult:
+        """Check if at least one sprint exists.
+
+        Args:
+            verbose: Include sprint details.
+
+        Returns:
+            CheckResult for sprint existence.
+        """
+        claudesprint_dir = self.project_root / ".claudesprint"
+        state_dir = claudesprint_dir / "state"
+
+        if not state_dir.exists():
+            return CheckResult(
+                name="Sprint Status",
+                status=CheckStatus.WARNING,
+                message="No state directory (no sprints)",
+                details="Initialize sprint with: claudesprint init --spec <file>" if verbose else None,
+            )
+
+        # Look for sprint files (sprint_*.json pattern)
+        sprint_files = list(state_dir.glob("sprint_*.json"))
+
+        if not sprint_files:
+            return CheckResult(
+                name="Sprint Status",
+                status=CheckStatus.WARNING,
+                message="No sprints found",
+                details=(
+                    "Initialize with: claudesprint init --spec <file>"
+                    if verbose
+                    else None
+                ),
+                fixable=False,
+                fix_command="claudesprint init --spec <file>",
+            )
+
+        # Find the current/most recent sprint
+        current_sprint_file = state_dir / "current_sprint.json"
+        if current_sprint_file.exists():
+            return CheckResult(
+                name="Sprint Status",
+                status=CheckStatus.OK,
+                message=f"Active sprint found ({len(sprint_files)} total)",
+                details=(
+                    f"Sprint files: {', '.join(f.stem for f in sprint_files)}"
+                    if verbose
+                    else None
+                ),
+            )
+
+        return CheckResult(
+            name="Sprint Status",
+            status=CheckStatus.OK,
+            message=f"{len(sprint_files)} sprint(s) found",
+            details=(
+                f"Sprint files: {', '.join(f.stem for f in sprint_files)}"
+                if verbose
+                else None
+            ),
+        )
 
     def check_project_structure(self, verbose: bool = False) -> CheckResult:
         """Check if project has ClaudeSprint structure.

--- a/claudesprint/services/health_check_service.py
+++ b/claudesprint/services/health_check_service.py
@@ -295,7 +295,8 @@ class HealthCheckService:
     def check_claude_auth(self, verbose: bool = False) -> CheckResult:
         """Check if Claude CLI is authenticated.
 
-        Runs a simple Claude CLI command to verify authentication status.
+        Checks for the presence of Claude credentials file to verify auth status.
+        This is faster and more reliable than running CLI commands.
 
         Args:
             verbose: Include authentication details.
@@ -313,65 +314,36 @@ class HealthCheckService:
                 details="Install Claude CLI first" if verbose else None,
             )
 
-        try:
-            # Use 'claude api-key' or similar lightweight check
-            # The 'claude --version' works but doesn't test auth
-            # Try using 'claude config list' which requires auth
-            result = subprocess.run(
-                ["claude", "config", "list"],
-                capture_output=True,
-                text=True,
-                timeout=self.version_check_timeout,
-            )
+        # Check for credentials file directly - this is fast and reliable
+        credentials_path = Path.home() / ".claude" / ".credentials.json"
 
-            if result.returncode == 0:
-                return CheckResult(
-                    name="Claude CLI Auth",
-                    status=CheckStatus.OK,
-                    message="Claude CLI authenticated",
-                    details=f"Config available" if verbose else None,
-                )
-            else:
-                # Check for specific auth error messages
-                error_output = result.stderr.lower()
-                if "not logged in" in error_output or "auth" in error_output:
+        if credentials_path.exists():
+            try:
+                # Verify the file has some content (basic sanity check)
+                content = credentials_path.read_text()
+                if len(content) > 10:  # Minimal valid JSON would be at least this long
                     return CheckResult(
                         name="Claude CLI Auth",
-                        status=CheckStatus.ERROR,
-                        message="Claude CLI not authenticated",
-                        details=(
-                            "Run 'claude login' to authenticate with your Anthropic account"
-                            if verbose
-                            else None
-                        ),
-                        fixable=False,
-                        fix_command="claude login",
+                        status=CheckStatus.OK,
+                        message="Claude CLI authenticated",
+                        details=f"Credentials found at {credentials_path}" if verbose else None,
                     )
-                else:
-                    return CheckResult(
-                        name="Claude CLI Auth",
-                        status=CheckStatus.WARNING,
-                        message="Claude CLI auth status unclear",
-                        details=(
-                            f"Check manually with 'claude config list'\nError: {result.stderr.strip()}"
-                            if verbose
-                            else None
-                        ),
-                    )
-        except subprocess.TimeoutExpired:
-            return CheckResult(
-                name="Claude CLI Auth",
-                status=CheckStatus.WARNING,
-                message="Auth check timed out",
-                details="Claude CLI may be unresponsive" if verbose else None,
-            )
-        except (subprocess.SubprocessError, OSError) as e:
-            return CheckResult(
-                name="Claude CLI Auth",
-                status=CheckStatus.WARNING,
-                message="Could not check auth status",
-                details=str(e) if verbose else None,
-            )
+            except (OSError, PermissionError):
+                pass
+
+        # No credentials file found
+        return CheckResult(
+            name="Claude CLI Auth",
+            status=CheckStatus.ERROR,
+            message="Claude CLI not authenticated",
+            details=(
+                "Run 'claude login' to authenticate with your Anthropic account"
+                if verbose
+                else None
+            ),
+            fixable=False,
+            fix_command="claude login",
+        )
 
     def check_project_initialized(self, verbose: bool = False) -> CheckResult:
         """Check if project has been initialized with ClaudeSprint.
@@ -390,12 +362,12 @@ class HealthCheckService:
                 status=CheckStatus.WARNING,
                 message="Project not initialized",
                 details=(
-                    "Run 'claudesprint quickstart' or 'claudesprint initrepo' to initialize"
+                    "Run 'claudesprint quickstart' or 'claudesprint quickstart' to initialize"
                     if verbose
                     else None
                 ),
                 fixable=True,
-                fix_command="claudesprint initrepo",
+                fix_command="claudesprint quickstart",
             )
 
         # Check for essential directories
@@ -405,9 +377,9 @@ class HealthCheckService:
                 name="Project Initialized",
                 status=CheckStatus.WARNING,
                 message="Project partially initialized (missing state/)",
-                details="Run 'claudesprint initrepo' to complete setup" if verbose else None,
+                details="Run 'claudesprint quickstart' to complete setup" if verbose else None,
                 fixable=True,
-                fix_command="claudesprint initrepo",
+                fix_command="claudesprint quickstart",
             )
 
         return CheckResult(
@@ -565,12 +537,12 @@ class HealthCheckService:
                 status=CheckStatus.WARNING,
                 message="No .claudesprint/ directory found",
                 details=(
-                    "Run 'claudesprint initrepo' to initialize ClaudeSprint in this project"
+                    "Run 'claudesprint quickstart' to initialize ClaudeSprint in this project"
                     if verbose
                     else None
                 ),
                 fixable=True,
-                fix_command="claudesprint initrepo",
+                fix_command="claudesprint quickstart",
             )
 
         # Check for expected subdirectories

--- a/claudesprint/services/spec_service.py
+++ b/claudesprint/services/spec_service.py
@@ -1,0 +1,358 @@
+"""Service for managing spec files.
+
+Provides functionality for listing, validating, creating, and reading
+project spec files used to initialize sprints.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, PackageLoader, TemplateNotFound
+
+
+@dataclass
+class SpecValidationResult:
+    """Result of spec file validation."""
+
+    valid: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    title: str | None = None
+    sections_found: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SpecInfo:
+    """Information about a spec file."""
+
+    name: str
+    path: Path
+    title: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class SpecTemplate:
+    """Information about a spec template."""
+
+    name: str
+    display_name: str
+    description: str
+
+
+# Available templates with metadata
+SPEC_TEMPLATES: list[SpecTemplate] = [
+    SpecTemplate(
+        name="web-application",
+        display_name="Web Application",
+        description="Express/React/SQLite stack with API and frontend",
+    ),
+    SpecTemplate(
+        name="cli-tool",
+        display_name="CLI Tool",
+        description="Python CLI with Typer framework",
+    ),
+    SpecTemplate(
+        name="api-service",
+        display_name="API Service",
+        description="FastAPI REST service with database",
+    ),
+    SpecTemplate(
+        name="minimal",
+        display_name="Minimal",
+        description="Blank template with basic structure only",
+    ),
+]
+
+
+class SpecService:
+    """Service for managing spec files.
+
+    Handles listing, validation, creation from templates, and reading
+    of spec files in the .claudesprint/specs/ directory.
+    """
+
+    SPECS_DIR = "specs"
+    CLAUDESPRINT_DIR = ".claudesprint"
+
+    def __init__(self, project_root: str | Path) -> None:
+        """Initialize the service.
+
+        Args:
+            project_root: Path to the project root directory.
+        """
+        self.project_root = Path(project_root)
+        self.claudesprint_dir = self.project_root / self.CLAUDESPRINT_DIR
+        self.specs_dir = self.claudesprint_dir / self.SPECS_DIR
+
+    def list_specs(self) -> list[SpecInfo]:
+        """List all spec files.
+
+        Looks for .md files in .claudesprint/specs/ and .claudesprint/.
+
+        Returns:
+            List of SpecInfo objects for each spec file found.
+        """
+        specs: list[SpecInfo] = []
+
+        # Check specs directory
+        if self.specs_dir.exists():
+            for spec_file in sorted(self.specs_dir.glob("*.md")):
+                info = self._get_spec_info(spec_file)
+                specs.append(info)
+
+        # Also check root .claudesprint directory for .md files
+        if self.claudesprint_dir.exists():
+            for spec_file in sorted(self.claudesprint_dir.glob("*.md")):
+                # Skip README.md and other non-spec files
+                if spec_file.name.lower() in ("readme.md",):
+                    continue
+                info = self._get_spec_info(spec_file)
+                specs.append(info)
+
+        return specs
+
+    def get_spec(self, name: str) -> SpecInfo | None:
+        """Get a spec by name.
+
+        Args:
+            name: Spec name (with or without .md extension).
+
+        Returns:
+            SpecInfo if found, None otherwise.
+        """
+        # Normalize name
+        if not name.endswith(".md"):
+            name = f"{name}.md"
+
+        # Check specs directory first
+        spec_path = self.specs_dir / name
+        if spec_path.exists():
+            return self._get_spec_info(spec_path)
+
+        # Check root .claudesprint directory
+        spec_path = self.claudesprint_dir / name
+        if spec_path.exists():
+            return self._get_spec_info(spec_path)
+
+        return None
+
+    def read_spec(self, name: str) -> str | None:
+        """Read spec file content.
+
+        Args:
+            name: Spec name (with or without .md extension).
+
+        Returns:
+            File content as string, or None if not found.
+        """
+        spec = self.get_spec(name)
+        if spec is None:
+            return None
+        return spec.path.read_text()
+
+    def validate_spec(self, name: str) -> SpecValidationResult:
+        """Validate a spec file.
+
+        Checks for required sections and structure.
+
+        Args:
+            name: Spec name (with or without .md extension).
+
+        Returns:
+            SpecValidationResult with validation status and details.
+        """
+        content = self.read_spec(name)
+
+        if content is None:
+            return SpecValidationResult(
+                valid=False,
+                errors=[f"Spec file '{name}' not found"],
+            )
+
+        return self._validate_content(content)
+
+    def validate_content(self, content: str) -> SpecValidationResult:
+        """Validate spec content directly.
+
+        Args:
+            content: Spec file content.
+
+        Returns:
+            SpecValidationResult with validation status and details.
+        """
+        return self._validate_content(content)
+
+    def _validate_content(self, content: str) -> SpecValidationResult:
+        """Internal validation of spec content.
+
+        Args:
+            content: Spec file content.
+
+        Returns:
+            SpecValidationResult with validation status.
+        """
+        result = SpecValidationResult(valid=True)
+
+        # Check for title (# heading at start)
+        title_match = re.search(r"^#\s+(.+)$", content, re.MULTILINE)
+        if title_match:
+            result.title = title_match.group(1).strip()
+        else:
+            result.warnings.append("No title heading (# Title) found")
+
+        # Check for sections (## headings)
+        sections = re.findall(r"^##\s+(.+)$", content, re.MULTILINE)
+        result.sections_found = sections
+
+        if not sections:
+            result.warnings.append("No sections (## Section) found")
+
+        # Check for minimum content
+        if len(content.strip()) < 50:
+            result.errors.append("Spec content is too short (< 50 characters)")
+            result.valid = False
+
+        # Check for recommended sections
+        recommended_sections = {"Overview", "Goals", "Requirements", "Issues", "Features"}
+        found_sections_lower = {s.lower() for s in sections}
+
+        has_issues = any(
+            keyword in found_sections_lower
+            for keyword in ("issues", "tasks", "user stories", "features", "requirements")
+        )
+
+        if not has_issues:
+            result.warnings.append(
+                "Consider adding an 'Issues' or 'Features' section with specific tasks"
+            )
+
+        return result
+
+    def create_spec(
+        self,
+        name: str,
+        template: str,
+        project_name: str,
+        description: str = "",
+    ) -> Path:
+        """Create a spec file from a template.
+
+        Args:
+            name: Name for the spec file (without .md extension).
+            template: Template name (e.g., "web-application", "cli-tool").
+            project_name: Name of the project.
+            description: Brief description of the project.
+
+        Returns:
+            Path to the created spec file.
+
+        Raises:
+            ValueError: If template is not found.
+            OSError: If directory creation or file writing fails.
+        """
+        # Ensure specs directory exists
+        self.specs_dir.mkdir(parents=True, exist_ok=True)
+
+        # Load and render template
+        try:
+            env = Environment(
+                loader=PackageLoader("claudesprint", "templates/specs"),
+                autoescape=False,
+                keep_trailing_newline=True,
+            )
+            template_obj = env.get_template(f"{template}.md.j2")
+        except TemplateNotFound:
+            raise ValueError(f"Template '{template}' not found")
+
+        content = template_obj.render(
+            project_name=project_name,
+            description=description,
+        )
+
+        # Write spec file
+        spec_name = self._normalize_name(name)
+        spec_path = self.specs_dir / f"{spec_name}.md"
+        spec_path.write_text(content)
+
+        return spec_path
+
+    def get_templates(self) -> list[SpecTemplate]:
+        """Get list of available spec templates.
+
+        Returns:
+            List of SpecTemplate objects.
+        """
+        return SPEC_TEMPLATES.copy()
+
+    def _get_spec_info(self, path: Path) -> SpecInfo:
+        """Extract spec info from a file.
+
+        Args:
+            path: Path to the spec file.
+
+        Returns:
+            SpecInfo with extracted metadata.
+        """
+        name = path.stem
+        title = None
+        description = None
+
+        try:
+            content = path.read_text()
+
+            # Extract title from first # heading
+            title_match = re.search(r"^#\s+(.+)$", content, re.MULTILINE)
+            if title_match:
+                title = title_match.group(1).strip()
+
+            # Extract description from first paragraph after title
+            # Look for text after the title line and before the next heading
+            desc_match = re.search(
+                r"^#\s+.+\n\n(.+?)(?:\n\n|\n#|\Z)",
+                content,
+                re.MULTILINE | re.DOTALL,
+            )
+            if desc_match:
+                description = desc_match.group(1).strip()
+                # Limit to first sentence or 100 chars
+                if len(description) > 100:
+                    description = description[:97] + "..."
+
+        except (OSError, UnicodeDecodeError):
+            pass
+
+        return SpecInfo(
+            name=name,
+            path=path,
+            title=title,
+            description=description,
+        )
+
+    def _normalize_name(self, name: str) -> str:
+        """Normalize a spec name for use as filename.
+
+        Converts to lowercase, replaces spaces with hyphens,
+        removes special characters.
+
+        Args:
+            name: Raw name input.
+
+        Returns:
+            Normalized name safe for use as filename.
+        """
+        # Lowercase and replace spaces with hyphens
+        name = name.lower().strip()
+        name = re.sub(r"\s+", "-", name)
+        # Remove special characters except hyphens and underscores
+        name = re.sub(r"[^a-z0-9\-_]", "", name)
+        # Collapse multiple hyphens
+        name = re.sub(r"-+", "-", name)
+        # Remove leading/trailing hyphens
+        name = name.strip("-")
+
+        return name or "spec"

--- a/claudesprint/templates/specs/api-service.md.j2
+++ b/claudesprint/templates/specs/api-service.md.j2
@@ -1,0 +1,108 @@
+# {{ project_name }}
+
+{{ description if description else "A RESTful API service built with FastAPI." }}
+
+## Overview
+
+This project implements a REST API service with:
+- **Framework**: FastAPI for high-performance async API
+- **Database**: PostgreSQL with SQLAlchemy ORM
+- **Validation**: Pydantic for request/response schemas
+- **Testing**: pytest with httpx for async testing
+
+## Technical Stack
+
+- **Language**: Python 3.10+
+- **Framework**: FastAPI
+- **ORM**: SQLAlchemy 2.0 (async)
+- **Database**: PostgreSQL (or SQLite for development)
+- **Validation**: Pydantic v2
+- **Testing**: pytest, pytest-asyncio, httpx
+
+## Project Structure
+
+```
+{{ project_name | lower | replace(' ', '-') }}/
+├── src/
+│   └── {{ project_name | lower | replace(' ', '_') | replace('-', '_') }}/
+│       ├── __init__.py
+│       ├── main.py           # FastAPI app entry
+│       ├── routers/          # API route handlers
+│       ├── models/           # SQLAlchemy models
+│       ├── schemas/          # Pydantic schemas
+│       ├── services/         # Business logic
+│       └── database.py       # Database connection
+├── tests/
+│   ├── conftest.py           # Test fixtures
+│   ├── test_routers/
+│   └── test_services/
+├── alembic/                  # Database migrations
+├── pyproject.toml
+└── README.md
+```
+
+## Issues
+
+### Issue 1: Project Setup
+Initialize the FastAPI project with proper structure and dependencies.
+
+**Acceptance Criteria:**
+- FastAPI app runs with `uvicorn`
+- Auto-generated OpenAPI docs at `/docs`
+- Health check endpoint at `/health`
+
+### Issue 2: Database Configuration
+Set up SQLAlchemy with async support and connection pooling.
+
+**Acceptance Criteria:**
+- Database connection configured via environment
+- Connection pool with sensible defaults
+- Graceful shutdown of connections
+
+### Issue 3: Database Models
+Create SQLAlchemy models for the core domain entities.
+
+**Acceptance Criteria:**
+- Models with proper relationships
+- Timestamps for created/updated tracking
+- Indexes for common query patterns
+
+### Issue 4: Pydantic Schemas
+Define request and response schemas with validation.
+
+**Acceptance Criteria:**
+- Schemas for all API operations
+- Validation with helpful error messages
+- OpenAPI schema generation
+
+### Issue 5: CRUD Endpoints
+Implement Create, Read, Update, Delete endpoints for core resources.
+
+**Acceptance Criteria:**
+- RESTful URL patterns
+- Pagination for list endpoints
+- Filtering and sorting support
+
+### Issue 6: Error Handling
+Implement consistent error handling across the API.
+
+**Acceptance Criteria:**
+- Custom exception handlers
+- Consistent error response format
+- Appropriate HTTP status codes
+
+### Issue 7: Authentication
+Implement authentication for protected endpoints.
+
+**Acceptance Criteria:**
+- JWT or API key authentication
+- Protected route dependencies
+- User context in request
+
+### Issue 8: Testing
+Write comprehensive API tests with database fixtures.
+
+**Acceptance Criteria:**
+- Test database setup/teardown
+- Tests for all endpoints
+- Edge case and error testing

--- a/claudesprint/templates/specs/cli-tool.md.j2
+++ b/claudesprint/templates/specs/cli-tool.md.j2
@@ -1,0 +1,104 @@
+# {{ project_name }}
+
+{{ description if description else "A command-line tool built with Python and Typer." }}
+
+## Overview
+
+This project implements a Python CLI application with:
+- **CLI Framework**: Typer for command parsing and help generation
+- **Output**: Rich for formatted terminal output
+- **Configuration**: TOML-based configuration files
+- **Testing**: pytest with high coverage
+
+## Technical Stack
+
+- **Language**: Python 3.10+
+- **CLI Framework**: Typer
+- **Output Formatting**: Rich
+- **Configuration**: tomli/tomllib
+- **Testing**: pytest, pytest-cov
+
+## Project Structure
+
+```
+{{ project_name | lower | replace(' ', '-') }}/
+├── src/
+│   └── {{ project_name | lower | replace(' ', '_') | replace('-', '_') }}/
+│       ├── __init__.py
+│       ├── cli.py            # Main CLI entry point
+│       ├── commands/         # Command implementations
+│       ├── services/         # Business logic
+│       └── utils/            # Helper utilities
+├── tests/
+│   ├── test_cli.py
+│   ├── test_commands/
+│   └── test_services/
+├── pyproject.toml
+└── README.md
+```
+
+## Issues
+
+### Issue 1: Project Structure Setup
+Initialize the Python project with pyproject.toml, src layout, and development dependencies.
+
+**Acceptance Criteria:**
+- Project installable with `pip install -e .`
+- Dev dependencies in optional group
+- Entry point configured for CLI
+
+### Issue 2: CLI Framework Setup
+Set up Typer CLI with main app, version flag, and help documentation.
+
+**Acceptance Criteria:**
+- `--version` flag shows version
+- `--help` shows formatted help text
+- Command groups organized logically
+
+### Issue 3: Configuration System
+Implement configuration file loading with hierarchical precedence (CLI > env > file > defaults).
+
+**Acceptance Criteria:**
+- Config file auto-discovered in standard locations
+- Environment variable overrides
+- CLI flag overrides for common options
+
+### Issue 4: Core Command Implementation
+Implement the primary command(s) that provide the main functionality.
+
+**Acceptance Criteria:**
+- Clear command interface with required and optional arguments
+- Progress indicators for long-running operations
+- Helpful error messages on failure
+
+### Issue 5: Output Formatting
+Use Rich for formatted, colorful terminal output with tables and panels.
+
+**Acceptance Criteria:**
+- Consistent styling across commands
+- Table output for structured data
+- Color-coded status messages
+
+### Issue 6: Error Handling
+Implement comprehensive error handling with user-friendly messages.
+
+**Acceptance Criteria:**
+- Custom exception classes for domain errors
+- Exit codes follow Unix conventions
+- Verbose mode shows stack traces
+
+### Issue 7: Testing Suite
+Write comprehensive tests for all commands and services.
+
+**Acceptance Criteria:**
+- Unit tests for business logic
+- CLI integration tests using CliRunner
+- >80% code coverage
+
+### Issue 8: Documentation
+Create user documentation and usage examples.
+
+**Acceptance Criteria:**
+- README with installation and quick start
+- Command reference documentation
+- Example usage for common workflows

--- a/claudesprint/templates/specs/demo.md
+++ b/claudesprint/templates/specs/demo.md
@@ -1,0 +1,38 @@
+# Hello World CLI
+
+## Overview
+
+A simple command-line tool that greets users by name.
+
+## Constraints
+
+- Python 3.10+
+- No external dependencies beyond standard library
+- Must be runnable with `python hello.py`
+
+## Deliverables
+
+A working Python script that:
+- Accepts an optional name argument
+- Prints a personalized greeting
+- Has basic error handling
+
+## Work Plan
+
+### Issue 1: Create Hello World Script
+
+Create `hello.py` that greets users.
+
+**Acceptance Criteria:**
+- Running `python hello.py` prints "Hello, World!"
+- Running `python hello.py Alice` prints "Hello, Alice!"
+- The script handles missing arguments gracefully
+
+### Issue 2: Add Unit Tests
+
+Create tests for the hello script.
+
+**Acceptance Criteria:**
+- Test default greeting
+- Test custom name greeting
+- Tests pass with `python -m pytest` or similar

--- a/claudesprint/templates/specs/minimal.md.j2
+++ b/claudesprint/templates/specs/minimal.md.j2
@@ -1,0 +1,30 @@
+# {{ project_name }}
+
+{{ description if description else "Project description goes here." }}
+
+## Overview
+
+Describe the project goals and high-level architecture here.
+
+## Technical Stack
+
+- List technologies and frameworks
+- Specify versions where important
+
+## Issues
+
+### Issue 1: [First Task]
+Describe what needs to be done.
+
+**Acceptance Criteria:**
+- List specific requirements
+- Include testable conditions
+
+### Issue 2: [Second Task]
+Describe what needs to be done.
+
+**Acceptance Criteria:**
+- List specific requirements
+- Include testable conditions
+
+<!-- Add more issues as needed -->

--- a/claudesprint/templates/specs/web-application.md.j2
+++ b/claudesprint/templates/specs/web-application.md.j2
@@ -1,0 +1,107 @@
+# {{ project_name }}
+
+{{ description if description else "A modern web application with API backend and interactive frontend." }}
+
+## Overview
+
+This project implements a full-stack web application with:
+- **Backend**: Express.js REST API with SQLite database
+- **Frontend**: React single-page application
+- **Authentication**: JWT-based user authentication
+- **Testing**: Jest for backend, React Testing Library for frontend
+
+## Technical Stack
+
+- **Runtime**: Node.js 18+
+- **Backend Framework**: Express.js
+- **Database**: SQLite with better-sqlite3
+- **Frontend Framework**: React 18
+- **Build Tool**: Vite
+- **Testing**: Jest, React Testing Library
+
+## Project Structure
+
+```
+{{ project_name | lower | replace(' ', '-') }}/
+├── server/
+│   ├── src/
+│   │   ├── index.ts          # Express app entry
+│   │   ├── routes/           # API routes
+│   │   ├── models/           # Database models
+│   │   └── middleware/       # Express middleware
+│   └── tests/
+├── client/
+│   ├── src/
+│   │   ├── App.tsx           # Main component
+│   │   ├── components/       # React components
+│   │   ├── pages/            # Page components
+│   │   └── hooks/            # Custom hooks
+│   └── tests/
+└── package.json
+```
+
+## Issues
+
+### Issue 1: Project Setup
+Set up the monorepo structure with server and client directories. Initialize package.json with scripts for development, testing, and building.
+
+**Acceptance Criteria:**
+- Running `npm install` installs all dependencies
+- Running `npm run dev` starts both server and client
+- TypeScript configured for both packages
+
+### Issue 2: Database Schema and Models
+Design and implement the SQLite database schema. Create model classes for data access.
+
+**Acceptance Criteria:**
+- Database file created on first run
+- Migration system for schema changes
+- Model methods for CRUD operations
+
+### Issue 3: REST API Endpoints
+Implement the core REST API endpoints with Express.js.
+
+**Acceptance Criteria:**
+- RESTful endpoints following conventions
+- Request validation with appropriate error responses
+- API documentation in code comments
+
+### Issue 4: Authentication System
+Implement JWT-based authentication with login, logout, and protected routes.
+
+**Acceptance Criteria:**
+- User registration and login endpoints
+- JWT token generation and validation
+- Protected route middleware
+
+### Issue 5: React Frontend Setup
+Set up the React frontend with Vite, routing, and basic layout.
+
+**Acceptance Criteria:**
+- Vite development server configured
+- React Router for navigation
+- Base layout with navigation component
+
+### Issue 6: Frontend Components
+Build the main UI components for interacting with the API.
+
+**Acceptance Criteria:**
+- Form components for data entry
+- List/table components for data display
+- Loading and error state handling
+
+### Issue 7: API Integration
+Connect the frontend to the backend API with proper error handling.
+
+**Acceptance Criteria:**
+- API client utility for HTTP requests
+- Authentication token handling
+- Error boundary for API failures
+
+### Issue 8: Testing Suite
+Implement comprehensive tests for both backend and frontend.
+
+**Acceptance Criteria:**
+- Unit tests for API endpoints
+- Component tests for React components
+- Integration tests for critical flows


### PR DESCRIPTION
## Summary

Simplifies the CLI for public release by removing stale features, improving first-run experience, and reducing code duplication.

### Added
- **First-run welcome screen** - Detects Claude CLI status and guides new users
- **`demo` command** - Try ClaudeSprint with a sample project instantly
- **Grouped help output** - Commands organized by user journey (Getting Started, Workflow, Setup, Utilities)

### Removed
- `plan` command (undocumented, confused users)
- `notify` command (internal admin feature, unused)
- `initrepo` command (merged into `init`)
- `--dashboard` flag (rarely used, heavy dependency)
- `--goal` option (half-baked, users should use `spec create`)
- `spec templates` subcommand (redundant with `spec create`)

### Changed
- `init` now auto-creates `.claudesprint/` if missing
- `quickstart` delegates to `init` instead of duplicating 80+ lines
- Auth check uses credentials file instead of timeout-prone CLI command

### Stats
- Commands: 17 → 13
- Net code: -200 lines

## Test plan

- [ ] `claudesprint` in new directory shows welcome screen
- [ ] `claudesprint demo --skip-run` creates demo project
- [ ] `claudesprint --help` shows grouped commands
- [ ] `claudesprint init --spec <name>` auto-creates `.claudesprint/`
- [ ] `claudesprint quickstart --non-interactive` works end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)